### PR TITLE
Fixed bugs

### DIFF
--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -68,23 +68,45 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 	return true;
 }
 
+/*
+	Sets "allNext" of followed
+	Each followed - follower pair is entered into follow_S_PairList
+	If followed already has a list of followers, it is not replaced and it return false
+*/
 bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 {
 	if (followTable.find(followed)->second.allNext.size() != 0)
 	{
 		return false;
 	}
+
 	followTable.find(followed)->second.allNext = followers;
+
+	for (auto itr = followers.cbegin; itr != followers.cend; ++itr)
+	{
+		follow_S_PairList.emplace(pair<int, int>(followed, *itr));
+	}
 	return true;
 }
 
+/*
+	Sets "allPrevious" of follower
+	Each followed - follower pair is entered into follow_S_PairList
+	If follower already has a list of followed, it is not replaced and it return false
+*/
 bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 {
 	if (followTable.find(follower)->second.allPrevious.size() != 0)
 	{
 		return false;
 	}
+
 	followTable.find(follower)->second.allPrevious = followed;
+
+	for (auto itr = followed.cbegin; itr != followed.cend; ++itr)
+	{
+		follow_S_PairList.emplace(pair<int, int>(follower, *itr));
+	}
 	return true;
 }
 

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -19,38 +19,40 @@ FollowStorage::FollowStorage()
 */
 bool FollowStorage::addFollowPair(int followed, int follower)
 {
-	// if follows Pair is already added, return false
+	// if follows Pair is already added
 	if (!followPairList.emplace(pair<int, int>(followed, follower)).second)
 	{
 		return false;
 	}
 
-	// if followed exist in followTable and has "next" initialized, return false
-	auto itrpr1 = followTable.emplace(followed, fRelationships{ 0, follower, {}, {} });
-	if (!itrpr1.second && followTable.find(followed)->second.next != 0)
+	if (followTable.find(followed) != followTable.end() &&
+		followTable.find(followed)->second.next != 0)
 	{
+		followPairList.erase(pair<int, int>(followed, follower));
 		return false;
 	}
 
-	// if follower exist in followTable and has "previous" initialized, return false
-	auto itrpr2 = followTable.emplace(follower, fRelationships{ followed, 0, {}, {} });
-	if (!itrpr2.second && followTable.find(follower)->second.previous != 0)
+	if (followTable.find(follower) != followTable.end() &&
+		followTable.find(follower)->second.previous != 0)
 	{
+		followPairList.erase(pair<int, int>(followed, follower));
 		return false;
 	}
 
-	// if a new followed statement, add it to the list of roots
-	if (itrpr1.second)
+	// if followed is a new statement
+	if (followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
 	{
 		rootList.emplace(followed);
 	}
-	else	// followed is not a statement and does not have "next" initialized
+	else
 	{
-		itrpr1.first->second.next = follower;
+		followTable.find(followed)->second.next = follower;
 	}
-	if (!itrpr2.second)		//follower is not a new statement and does not "previous" initialized
+
+	// if follower is a not new statement
+	if (!followTable.emplace(follower, fRelationships{ followed, 0, {}, {} }).second)
 	{
-		itrpr2.first->second.previous = followed;
+		followTable.find(follower)->second.previous = followed;
 		if (rootList.find(follower) != rootList.end())	//if follower was a root
 		{
 			rootList.erase(follower);
@@ -121,28 +123,56 @@ bool FollowStorage::containsFSPair(pair<int, int> pair)
 	return follow_S_PairList.find(pair) != follow_S_PairList.end();
 }
 
-// return the statement following the statement specified by the index
+/*
+	return the statement following the statement specified
+	return 0 if 'stm' is not found
+*/
 int FollowStorage::getNextOf(int stm)
 {
-	return followTable.at(stm).next;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).next;
+	}
+	return 0;
 }
 
-// return the statement being followed by the statement specified by the index
+/*
+	return the statement followed by the statement specified
+	return 0 if 'stm' is not found
+*/
 int FollowStorage::getPrevOf(int stm)
 {
-	return followTable.at(stm).previous;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).previous;
+	}
+	return 0;
 }
 
-// return a list of statements that is directly/indirectly following the statement specified by index
+/*
+	return a list of statements that is directly/indirectly following the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> FollowStorage::getAllFollowing(int stm)
 {
-	return followTable.at(stm).allNext;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).allNext;
+	}
+	return {};
 }
 
-// return a list of statements that is directly/indirectly followed by the statement specified by index
+/*
+	return a list of statements that is directly/indirectly followed by the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 {
-	return followTable.at(stm).allPrevious;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).allPrevious;
+	}
+	return {};
 }
 
 unordered_set<int> FollowStorage::getFollowerList()

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -19,38 +19,40 @@ FollowStorage::FollowStorage()
 */
 bool FollowStorage::addFollowPair(int followed, int follower)
 {
-	// if follows Pair is already added, return false
+	// if follows Pair is already added
 	if (!followPairList.emplace(pair<int, int>(followed, follower)).second)
 	{
 		return false;
 	}
 
-	// if followed exist in followTable and has "next" initialized, return false
-	auto itrpr1 = followTable.emplace(followed, fRelationships{ 0, follower, {}, {} });
-	if (!itrpr1.second && followTable.find(followed)->second.next != 0)
+	if (followTable.find(followed) != followTable.end() &&
+			followTable.find(followed)->second.next != 0)
 	{
+		followPairList.erase(pair<int, int>(followed, follower));
+		return false;
+	}
+	
+	if (followTable.find(follower) != followTable.end() &&
+			followTable.find(follower)->second.previous != 0)
+	{
+		followPairList.erase(pair<int, int>(followed, follower));
 		return false;
 	}
 
-	// if follower exist in followTable and has "previous" initialized, return false
-	auto itrpr2 = followTable.emplace(follower, fRelationships{ followed, 0, {}, {} });
-	if (!itrpr2.second && followTable.find(follower)->second.previous != 0)
-	{
-		return false;
-	}
-
-	// if a new followed statement, add it to the list of roots
-	if (itrpr1.second)
+	// if followed is a new statement
+	if (followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
 	{
 		rootList.emplace(followed);
 	}
-	else	// followed is not a statement and does not have "next" initialized
+	else
 	{
-		itrpr1.first->second.next = follower;
+		followTable.find(followed)->second.next = follower;
 	}
-	if (!itrpr2.second)		//follower is not a new statement and does not "previous" initialized
+
+	// if follower is a not new statement
+	if (!followTable.emplace(follower, fRelationships{ followed, 0, {}, {} }).second)
 	{
-		itrpr2.first->second.previous = followed;
+		followTable.find(follower)->second.previous = followed;
 		if (rootList.find(follower) != rootList.end())	//if follower was a root
 		{
 			rootList.erase(follower);
@@ -121,28 +123,56 @@ bool FollowStorage::containsFSPair(pair<int, int> pair)
 	return follow_S_PairList.find(pair) != follow_S_PairList.end();
 }
 
-// return the statement following the statement specified by the index
+/*
+	return the statement following the statement specified
+	return 0 if 'stm' is not found
+*/
 int FollowStorage::getNextOf(int stm)
 {
-	return followTable.at(stm).next;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).next;
+	}
+	return 0;
 }
 
-// return the statement being followed by the statement specified by the index
+/*
+	return the statement followed by the statement specified
+	return 0 if 'stm' is not found
+*/
 int FollowStorage::getPrevOf(int stm)
 {
-	return followTable.at(stm).previous;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).previous;
+	}
+	return 0;
 }
 
-// return a list of statements that is directly/indirectly following the statement specified by index
+/*
+	return a list of statements that is directly/indirectly following the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> FollowStorage::getAllFollowing(int stm)
 {
-	return followTable.at(stm).allNext;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).allNext;
+	}
+	return {};
 }
 
-// return a list of statements that is directly/indirectly followed by the statement specified by index
+/*
+	return a list of statements that is directly/indirectly followed by the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 {
-	return followTable.at(stm).allPrevious;
+	if (followTable.find(stm) != followTable.end())
+	{
+		return followTable.at(stm).allPrevious;
+	}
+	return {};
 }
 
 unordered_set<int> FollowStorage::getFollowerList()

--- a/Code/source/ModifyStorage.cpp
+++ b/Code/source/ModifyStorage.cpp
@@ -47,22 +47,38 @@ bool ModifyStorage::containsProcVarPair(pair<string, string> pair)
 
 string ModifyStorage::getVarModifiedBy(int stm)
 {
-	return varList_Stm.find(stm)->second;
+	if (varList_Stm.find(stm) != varList_Stm.end())
+	{
+		return varList_Stm.at(stm);
+	}
+	return "";
 }
 
 string ModifyStorage::getVarModifiedBy(string proc)
 {
-	return varList_Proc.find(proc)->second;
+	if (varList_Proc.find(proc) != varList_Proc.end())
+	{
+		return varList_Proc.at(proc);
+	}
+	return "";
 }
 
 unordered_set<int> ModifyStorage::getStmModifying(string variable)
 {
-	return stmLists.find(variable)->second;
+	if (stmLists.find(variable) != stmLists.end())
+	{
+		return stmLists.at(variable);
+	}
+	return {};
 }
 
 unordered_set<string> ModifyStorage::getProcModifying(string variable)
 {
-	return procLists.find(variable)->second;
+	if (procLists.find(variable) != procLists.end())
+	{
+		procLists.at(variable);
+	}
+	return {};
 }
 
 unordered_set<pair<int, string>, intStringhash> ModifyStorage::getStmVarPairs()

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -60,6 +60,11 @@ bool ParentStorage::addParent_Child(int parent, int child)
 	return true;
 }
 
+/*
+	Sets "ancestors" of the descendant
+	Each ancestor - descendant pair is entered into anc_DescPairList
+	If descendant already has a list of ancestors, it is not replaced and it return false
+*/
 bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 {
 	if (parentTable.find(descendant)->second.ancestors.size() != 0)
@@ -67,9 +72,19 @@ bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 		return false;
 	}
 	parentTable.find(descendant)->second.ancestors = ancestors;
+
+	for (auto itr = ancestors.begin; itr != ancestors.end; ++itr)
+	{
+		anc_DescPairList.emplace(pair<int, int>(*itr, descendant));
+	}
 	return true;
 }
 
+/*
+	Sets "descendants" of the ancestor
+	Each ancestor - descendant pair is entered into anc_DescPairList
+	If ancestor already has a list of descendants, it is not replaced and it return false
+*/
 bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 {
 	if (parentTable.find(ancestor)->second.descendants.size() != 0)
@@ -77,6 +92,11 @@ bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 		return false;
 	}
 	parentTable.find(ancestor)->second.descendants = descendants;
+
+	for (auto itr = descendants.begin; itr != descendants.end; ++itr)
+	{
+		anc_DescPairList.emplace(pair<int, int>(ancestor, *itr));
+	}
 	return true;
 }
 

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -18,16 +18,17 @@ ParentStorage::ParentStorage()
 */
 bool ParentStorage::addParent_Child(int parent, int child)
 {
-	// if Parent-Child Pair is already added, return false
+	// if Parent-Child Pair is already added
 	if (!parent_ChildPairList.emplace(pair<int, int>(parent, child)).second)
 	{
 		return false;
 	}
 
-	// if child exist in parentTable and has parent already initialized, return false
+	// if child exist in parentTable and has parent already initialized
 	auto itrpr = parentTable.emplace(child, pRelationships{ parent, {}, {}, {} });
 	if (!itrpr.second && parentTable.find(child)->second.parent != 0)
 	{
+		parent_ChildPairList.erase(pair<int, int>(parent, child));
 		return false;
 	}
 	else if (!itrpr.second)		// if child exist but does not have parent initialized
@@ -120,24 +121,56 @@ bool ParentStorage::containsAnc_Desc(pair<int, int> pair)
 	return anc_DescPairList.find(pair) != anc_DescPairList.end();
 }
 
+/*
+	return the statement that is the parent of the statement specified
+	return 0 if 'stm' is not found
+*/
 int ParentStorage::getParentOf(int stm)
 {
-	return parentTable.find(stm)->second.parent;
+	if (parentTable.find(stm) != parentTable.end())
+	{
+		return parentTable.at(stm).parent;
+	}
+	return 0;
 }
 
+/*
+	return the list of statements that is the children of the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> ParentStorage::getChildrenOf(int stm)
 {
-	return parentTable.find(stm)->second.children;
+	if (parentTable.find(stm) != parentTable.end())
+	{
+		return parentTable.at(stm).children;
+	}
+	return {};
 }
 
+/*
+	return the list of statements that is the ancestor of the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> ParentStorage::getAncestorsOf(int stm)
 {
-	return parentTable.find(stm)->second.ancestors;
+	if (parentTable.find(stm) != parentTable.end())
+	{
+		return parentTable.at(stm).ancestors;
+	}
+	return {};
 }
 
+/*
+	return the list of statements that is the descendants of the statement specified
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> ParentStorage::getDescendantsOf(int stm)
 {
-	return parentTable.find(stm)->second.descendants;
+	if (parentTable.find(stm) != parentTable.end())
+	{
+		return parentTable.at(stm).descendants;
+	}
+	return {};
 }
 
 unordered_set<int> ParentStorage::getParentList()

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -18,17 +18,16 @@ ParentStorage::ParentStorage()
 */
 bool ParentStorage::addParent_Child(int parent, int child)
 {
-	// if Parent-Child Pair is already added
+	// if Parent-Child Pair is already added, return false
 	if (!parent_ChildPairList.emplace(pair<int, int>(parent, child)).second)
 	{
 		return false;
 	}
 
-	// if child exist in parentTable and has parent already initialized
+	// if child exist in parentTable and has parent already initialized, return false
 	auto itrpr = parentTable.emplace(child, pRelationships{ parent, {}, {}, {} });
 	if (!itrpr.second && parentTable.find(child)->second.parent != 0)
 	{
-		parent_ChildPairList.erase(pair<int, int>(parent, child));
 		return false;
 	}
 	else if (!itrpr.second)		// if child exist but does not have parent initialized
@@ -121,56 +120,24 @@ bool ParentStorage::containsAnc_Desc(pair<int, int> pair)
 	return anc_DescPairList.find(pair) != anc_DescPairList.end();
 }
 
-/*
-	return the statement that is the parent of the statement specified
-	return 0 if 'stm' is not found
-*/
 int ParentStorage::getParentOf(int stm)
 {
-	if (parentTable.find(stm) != parentTable.end())
-	{
-		return parentTable.at(stm).parent;
-	}
-	return 0;
+	return parentTable.find(stm)->second.parent;
 }
 
-/*
-	return the list of statements that is the children of the statement specified
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getChildrenOf(int stm)
 {
-	if (parentTable.find(stm) != parentTable.end())
-	{
-		return parentTable.at(stm).children;
-	}
-	return {};
+	return parentTable.find(stm)->second.children;
 }
 
-/*
-	return the list of statements that is the ancestor of the statement specified
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getAncestorsOf(int stm)
 {
-	if (parentTable.find(stm) != parentTable.end())
-	{
-		return parentTable.at(stm).ancestors;
-	}
-	return {};
+	return parentTable.find(stm)->second.ancestors;
 }
 
-/*
-	return the list of statements that is the descendants of the statement specified
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getDescendantsOf(int stm)
 {
-	if (parentTable.find(stm) != parentTable.end())
-	{
-		return parentTable.at(stm).descendants;
-	}
-	return {};
+	return parentTable.find(stm)->second.descendants;
 }
 
 unordered_set<int> ParentStorage::getParentList()

--- a/Code/source/PostProcessor.cpp
+++ b/Code/source/PostProcessor.cpp
@@ -85,7 +85,8 @@ void PostProcessor::traverseFamilyTree(int curr, unordered_set<int> ancestry,
 	ancTable.emplace(curr, ancestry);
 	ancestry.emplace(curr);
 
-	for (auto child = pkb.getAllChildren().begin(); child != pkb.getAllChildren().end(); ++child)
+	unordered_set<int> children = pkb.getChildren(curr);
+	for (auto child = children.begin(); child != children.end(); ++child)
 	{
 		traverseFamilyTree(*child, ancestry, ancTable, descTable);
 	}

--- a/Code/source/UseStorage.cpp
+++ b/Code/source/UseStorage.cpp
@@ -47,22 +47,38 @@ bool UseStorage::containsProcVarPair(pair<string, string> pair)
 
 unordered_set<string> UseStorage::getVarUsedBy(int stm)
 {
-	return varLists_Stm.find(stm)->second;
+	if (varLists_Stm.find(stm) != varLists_Stm.end())
+	{
+		return varLists_Stm.at(stm);
+	}
+	return {};
 }
 
 unordered_set<string> UseStorage::getVarUsedBy(string proc)
 {
-	return varLists_Proc.find(proc)->second;
+	if (varLists_Proc.find(proc) != varLists_Proc.end())
+	{
+		return varLists_Proc.at(proc);
+	}
+	return {};
 }
 
 unordered_set<int> UseStorage::getStmUsing(string variable)
 {
-	return stmLists.find(variable)->second;
+	if (stmLists.find(variable) != stmLists.end())
+	{
+		return stmLists.at(variable);
+	}
+	return {};
 }
 
 unordered_set<string> UseStorage::getProcUsing(string variable)
 {
-	return procLists.find(variable)->second;
+	if (procLists.find(variable) != procLists.end())
+	{
+		return procLists.at(variable);
+	}
+	return {};
 }
 
 unordered_set<pair<int, string>, intStringhash> UseStorage::getStmVarPairs()


### PR DESCRIPTION
~~edited the PostProcessor to fix the bug where it will traverse infinitely~~
No longer relevant

Fixed a bug where Follows* & Parent* Pair List is not populating

Added checks to the four relations Storage classes. If the statement/procedure to find is not in the table, it will return 0/empty set {}/"" depending on the return type.
close #70 and possibly #71 