### PR TITLE
Fix a possible bug when querying substring of variables matched. Also added new test queries.

### DIFF
--- a/Code/Tests/queries1.txt
+++ b/Code/Tests/queries1.txt
@@ -146,7 +146,7 @@ none
 36 - comment
 assign a; if ifs;
 Select a such that Follows (ifs, a) pattern a ("minus2", _"sum"_)
-none
+10
 5000
 37 - comment
 assign a; if ifs;

--- a/Code/Tests/queries2.txt
+++ b/Code/Tests/queries2.txt
@@ -98,4 +98,38 @@ stmt s; assign a;
 Select a such that Parent (s, a)
 8, 10, 12, 14, 15, 16, 17, 19, 21, 22, 24, 25, 26, 27, 29, 31, 33, 35, 36, 37, 38, 39, 40
 5000
-21 - 
+21 - Modifies
+variable v;
+Select v such that Modifies(40, v)
+a
+5000
+22 - Modifies
+stmt s;
+Select s such that Modifies(s, "div")
+38, 35, 34, 32, 30, 28, 7, 14, 13, 11, 9, 6
+5000
+23 - Modifies
+stmt s;
+Select s such that Modifies(s, "asdzxc")
+none
+5000
+24 - Modifies something
+stmt s;
+Select s such that Modifies(s, _)
+1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40
+5000
+25 - Modifies by read
+variable v
+Select v such that Modifies(1, v)
+a
+5000
+26 - Modifies assign
+variable v;
+Select v such that Modifies(4, v)
+minus
+5000
+31 - Uses assign
+variable v;
+Select v such that Uses(40, v)
+b, div
+5000

--- a/Code/Tests/queries2.txt
+++ b/Code/Tests/queries2.txt
@@ -38,13 +38,64 @@ stmt s;
 Select s such that Follows*(3, s)
 4, 5, 6, 7, 41
 5000
-8 - ParentStar
+9 - FollowStar (No line number above 43)
+stmt s;
+Select s such that Follow*(44, s)
+none
+5000
+10 - FollowStar (No line above 43)
+stmt s;
+Select s such that Follow*(s, 44)
+none
+5000
+12 - Follow multi variable
+stmt s, s1;
+Select s such that Follows(s1, s)
+2, 3, 4, 5, 6, 7, 9, 11, 13, 15, 18, 22, 23, 24, 26, 27, 28, 30, 32, 34, 36, 38, 40, 41
+5000
+13 - Follow multi variable invalid query
+stmt s s1;
+Select s such that Follows(s1, s)
+none
+5000
+13 - ParentStar
 stmt s;
 Select s such that Parent*(7, s)
 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,8,9
 5000;
-9- ParentStar
+14- ParentStar
 stmt s;
 Select s such that Parent*(s, 12)
 7, 9, 11
 5000;
+15 - Parent
+stmt s;
+Select s such that Parent(s, 31)
+30
+5000
+16 - Parent
+stmt s;
+Select s such that Parent(32, s)
+33, 34
+5000
+17 - Parent
+stmt s;
+Select s such that Parent(34, s)
+35, 36, 37, 38
+5000
+18 - Parent
+stmt s;
+Select s such that Parent(40, s)
+none
+5000
+19 - Parent
+stmt s;
+Select s such that Parent(s, 2)
+none
+5000
+20 - Parent Multi
+stmt s; assign a;
+Select a such that Parent (s, a)
+8, 10, 12, 14, 15, 16, 17, 19, 21, 22, 24, 25, 26, 27, 29, 31, 33, 35, 36, 37, 38, 39, 40
+5000
+21 - 

--- a/Code/source/ExpressionUtil.cpp
+++ b/Code/source/ExpressionUtil.cpp
@@ -99,7 +99,7 @@ string ExpressionUtil::convertInfixToPrefix(string expression) {
 		operandStack.push(subexpre);
 	}
 			
-	return operandStack.top();
+	return " " + operandStack.top() + " ";
 
 }
 


### PR DESCRIPTION
For example given an expression 
y + 500 + abc123.

pattern a(/_ ,_"bc1")_ would match because pkb performs string matching.

Hence a white space is added at the front and back to prevent this situation from happening.

Also added some new test queries.