### PR TITLE
Allow better error reporting in Assign Statement

### DIFF
--- a/Code/AutoTester/source/TestWrapper.cpp
+++ b/Code/AutoTester/source/TestWrapper.cpp
@@ -45,7 +45,7 @@ void TestWrapper::parse(std::string filename) {
 
 			//Perform post-parsing Design Extraction.
 			de.extractDesigns(pkb);
-		} catch (char const* exception) {
+		} catch (string exception) {
 			std::cout << exception << std::flush;
 			exit(0);
 		}

--- a/Code/source/AssignParser.cpp
+++ b/Code/source/AssignParser.cpp
@@ -29,7 +29,7 @@ std::string AssignParser::parseLeft(std::string statement) {
 		return left;
 	}
 	else {
-		throw "Invalid Assign Expression!";
+		throw "Invalid Assign Statement! Statement : " + statement;
 	}
 }
 
@@ -43,7 +43,7 @@ std::string AssignParser::parseRight(std::string statement) {
 		return right;
 	}
 	else {
-		throw "Invalid Assign Expression!";
+		throw "Invalid Assign Statement! Statement : " + statement;
 	}
 }
 
@@ -54,7 +54,7 @@ string AssignParser::getLeft(string statement) {
 		return variable;
 	}
 	else {
-		throw "Invalid Variable Name!";
+		throw "Invalid Variable Name! Variable : " + variable;
 	}
 }
 
@@ -68,7 +68,7 @@ vector<string> AssignParser::getRightVariable(string statement) {
 		listVariable = ExpressionUtil::getVariables(expression);
 	}
 	else {
-		throw "Invalid Expression in Assign Statement";
+		throw "Invalid Expression in Assign Statement! Expression : " + expression; 
 	}
 
 	return listVariable;
@@ -85,7 +85,7 @@ vector<string> AssignParser::getRightConstant(string statement) {
 		listConstant = ExpressionUtil::getConstants(expression);
 	}
 	else {
-		throw "Invalid Expression in Assign Statement";
+		throw "Invalid Expression in Assign Statement!Expression : " + expression;
 	}
 
 	return listConstant;
@@ -102,7 +102,7 @@ string AssignParser::getPrefixExpression(string statement) {
 		postfixExpression = ExpressionUtil::convertInfixToPrefix(expression);
 	}
 	else {
-		throw "Invalid Expression in Assign Statement";
+		throw "Invalid Expression in Assign Statement!Expression : " + expression;
 	}
 
 	return postfixExpression;


### PR DESCRIPTION
Allow TestWrapper to show exact problems causing any exception

Allow AssignParser to return the context of the statement that is causing parsing error.