### PR TITLE
Change the logic of verifyInteger.

### DIFF
--- a/Code/UnitTesting/LexicalTokenTest.cpp
+++ b/Code/UnitTesting/LexicalTokenTest.cpp
@@ -17,6 +17,24 @@ namespace UnitTesting
 			Assert::AreEqual(true, result);
 		}
 
+		TEST_METHOD(testEmptyVariable)
+		{
+			bool result = LexicalToken::verifyName("");
+			Assert::AreEqual(false, result);
+		}
+
+		TEST_METHOD(testWhitespaceVariable)
+		{
+			bool result = LexicalToken::verifyName(" ");
+			Assert::AreEqual(false, result);
+		}
+
+		TEST_METHOD(testWhitespaceBetweenVariable)
+		{
+			bool result = LexicalToken::verifyName("aasd vasd");
+			Assert::AreEqual(false, result);
+		}
+
 		TEST_METHOD(testInvalidVariable)
 		{
 			bool result = LexicalToken::verifyName("1test");
@@ -32,6 +50,12 @@ namespace UnitTesting
 		TEST_METHOD(testValidInteger)
 		{
 			bool result = LexicalToken::verifyInteger("55");
+			Assert::AreEqual(true, result);
+		}
+
+		TEST_METHOD(testLongValidInteger)
+		{
+			bool result = LexicalToken::verifyInteger("999999999999999999999999999999999999999999999999999999999999999999");
 			Assert::AreEqual(true, result);
 		}
 

--- a/Code/source/LexicalToken.cpp
+++ b/Code/source/LexicalToken.cpp
@@ -4,9 +4,10 @@
 using namespace std;
 using namespace LexicalToken;
 
-//Check if string is a NAME Lexical. A Name Lexical starts with a alphabet and is followed by a string of alphanumerical
-//Characters. Returns true if input is suitable as a procedure name or variable name. Returns false otherwise.
-bool LexicalToken::verifyName(std::string name) {
+/*Check if string is a NAME Lexical. A Name Lexical starts with a alphabet and is followed by a string of alphanumerical
+ *Characters. Returns true if input is suitable as a procedure name or variable name. Returns false otherwise.
+ */
+ bool LexicalToken::verifyName(std::string name) {
 
 	//Check if first character is an alphabet
 	if (!isalpha(name[0])) {
@@ -24,17 +25,15 @@ bool LexicalToken::verifyName(std::string name) {
 	return true;
 }
 
-//Checks if string is an integer by trying to convert it into an long variable. If conversion succeeds,
-//then it is a decimal integer and returns true 
+/*Checks if string is an integer by trying checking if every character in the string
+ *is a digit. Returns true if every character is a digit and returns false if 1 of them
+ *is not a digit
+ */
 bool LexicalToken::verifyInteger(std::string number){
-	char* p;
-
-	long checkInteger = strtol(number.c_str(), &p, 10);
-
-	if (*p) {
-		return false;
+	for (size_t i = 0; i < number.length(); i++) {
+		if (!isdigit(number[i])) {
+			return false;
+		}
 	}
-	else {
-		return true;
-	}
+	return true;
 }

--- a/Code/source/LexicalToken.h
+++ b/Code/source/LexicalToken.h
@@ -3,7 +3,22 @@
 
 using namespace std;
 
+/* Contains a suite of verifiers to check simple Lexical Tokens in accordance
+ * to the SPA program. These includes the check on
+ * 
+ * (1) Verification that a name for variable or procedure starts with an alphabet
+ *     and that the remaining are either alphabets or numbers.
+ * (2) Verification that a string contains a valid Integer so that it can be considered
+ *     a constant.
+ */
 namespace LexicalToken {
+	/* verifyName checks that a given string contains a valid Name
+	 * A valid Name is one that is of the form LETTER(LETTER|DIGIT)*
+	 */
 	bool verifyName(std::string s);
+
+	/* verifyName checks that a given string contains a valid INTEGER
+	 * A valid Integer is one that is of the form DIGIT+
+	 */
 	bool verifyInteger(std::string n);
 }


### PR DESCRIPTION
Before this, verifyInteger may fail if Integer given was too long,
For example 99999999999999999999999999999999999999999999999999999999.

This is because verifyInteger checks if it is an integer simply by seeing if it can convert into a long.

Now the checks just makes sure that every chracter in the string is a digit. 