### PR TITLE
renaming methods and fields

### DIFF
--- a/Code/SPA/SPA.vcxproj.filters
+++ b/Code/SPA/SPA.vcxproj.filters
@@ -28,8 +28,26 @@
     <Filter Include="Source Files\PreProcessor">
       <UniqueIdentifier>{838d1f7d-5901-41d5-8dc9-9d539926cfa8}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\ProgramQueryLanguage">
+    <Filter Include="Header Files\PKB">
+      <UniqueIdentifier>{13f069e0-e954-466b-8505-cd15e8a90e05}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Parser">
+      <UniqueIdentifier>{d5afa46f-8448-45eb-8bec-f22c9552385d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\PreProcessor">
+      <UniqueIdentifier>{cac60fc2-d42d-435b-bad2-2c8b04b03f47}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\DesignExtractor">
+      <UniqueIdentifier>{d5df4c81-6521-4b5c-8f58-d5f722db13d7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\PQL">
       <UniqueIdentifier>{59c428df-1c3b-48a3-abe2-e4608eb59d89}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\PQL">
+      <UniqueIdentifier>{e1fc83d8-3017-42ba-af3b-a8d213df8973}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Utility">
+      <UniqueIdentifier>{1a3253b3-d885-4a23-b710-7bdbf7a229b8}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -57,9 +75,6 @@
     <ClCompile Include="..\source\Preprocesser.cpp">
       <Filter>Source Files\PreProcessor</Filter>
     </ClCompile>
-    <ClCompile Include="..\source\PrintParser.cpp">
-      <Filter>Source Files\PKB</Filter>
-    </ClCompile>
     <ClCompile Include="..\source\ModifyStorage.cpp">
       <Filter>Source Files\PKB</Filter>
     </ClCompile>
@@ -85,10 +100,10 @@
       <Filter>Source Files\Utility</Filter>
     </ClCompile>
     <ClCompile Include="..\source\QueryEvaluator.cpp">
-      <Filter>Source Files\ProgramQueryLanguage</Filter>
+      <Filter>Source Files\PQL</Filter>
     </ClCompile>
     <ClCompile Include="..\source\QueryParser.cpp">
-      <Filter>Source Files\ProgramQueryLanguage</Filter>
+      <Filter>Source Files\PQL</Filter>
     </ClCompile>
     <ClCompile Include="..\source\Statement.cpp">
       <Filter>Source Files\PreProcessor</Filter>
@@ -100,87 +115,90 @@
       <Filter>Source Files\PKB</Filter>
     </ClCompile>
     <ClCompile Include="..\source\QueryValidator.cpp">
-      <Filter>Source Files\ProgramQueryLanguage</Filter>
+      <Filter>Source Files\PQL</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\PrintParser.cpp">
+      <Filter>Source Files\Parser</Filter>
     </ClCompile>
     <ClCompile Include="..\source\ContainerUtil.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\Utility</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\source\PKB.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\FollowStorage.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
     <ClInclude Include="..\source\ParentStorage.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
-    <ClInclude Include="..\source\UseStorage.h">
-      <Filter>Header Files</Filter>
+    <ClInclude Include="..\source\FollowStorage.h">
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
     <ClInclude Include="..\source\ModifyStorage.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
-    <ClInclude Include="..\source\Hasher.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\QueryParser.h">
-      <Filter>Header Files</Filter>
+    <ClInclude Include="..\source\UseStorage.h">
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
     <ClInclude Include="..\source\AssignParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\LexicalToken.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\ExpressionUtil.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\StringUtil.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\ProcedureParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\Preprocesser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\Statement.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\QueryEvaluator.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\IfParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\WhileParser.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\Parser</Filter>
     </ClInclude>
     <ClInclude Include="..\source\ElseParser.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\Parser</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\IfParser.h">
+      <Filter>Header Files\Parser</Filter>
     </ClInclude>
     <ClInclude Include="..\source\Parser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\source\ReadParser.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\Parser</Filter>
     </ClInclude>
     <ClInclude Include="..\source\PrintParser.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\Parser</Filter>
     </ClInclude>
-    <ClInclude Include="..\source\ConditionalExp.h">
-      <Filter>Header Files</Filter>
+    <ClInclude Include="..\source\ProcedureParser.h">
+      <Filter>Header Files\Parser</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\ReadParser.h">
+      <Filter>Header Files\Parser</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\WhileParser.h">
+      <Filter>Header Files\Parser</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\Preprocesser.h">
+      <Filter>Header Files\PreProcessor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\Statement.h">
+      <Filter>Header Files\PreProcessor</Filter>
     </ClInclude>
     <ClInclude Include="..\source\DesignExtractor.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\DesignExtractor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\QueryEvaluator.h">
+      <Filter>Header Files\PQL</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\QueryParser.h">
+      <Filter>Header Files\PQL</Filter>
     </ClInclude>
     <ClInclude Include="..\source\QueryValidator.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\PQL</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\ConditionalExp.h">
+      <Filter>Header Files\Utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\ExpressionUtil.h">
+      <Filter>Header Files\Utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\Hasher.h">
+      <Filter>Header Files\Utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\LexicalToken.h">
+      <Filter>Header Files\Utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\StringUtil.h">
+      <Filter>Header Files\Utility</Filter>
     </ClInclude>
     <ClInclude Include="..\source\ContainerUtil.h">
-      <Filter>Header Files</Filter>
+      <Filter>Header Files\Utility</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Code/source/DesignExtractor.cpp
+++ b/Code/source/DesignExtractor.cpp
@@ -30,7 +30,7 @@ void DesignExtractor::processFollowStar()
 		if (directFollowStm != 0) {
 			unordered_set<int> followedByStar = pkb.getAllFollowing(directFollowStm);
 			followedByStar.insert(directFollowStm);
-			pkb.setFollowers(currStmt, followedByStar);
+			pkb.setAllFollowing(currStmt, followedByStar);
 		}
 	}
 
@@ -43,7 +43,7 @@ void DesignExtractor::processFollowStar()
 		if (directPrvStm != 0) {
 			unordered_set<int>  followStar = pkb.getAllFollowedBy(directPrvStm);
 			followStar.insert(directPrvStm);
-			pkb.setStmFollowedBy(currStmt, followStar);
+			pkb.setAllFollowedBy(currStmt, followStar);
 		}
 	}
 

--- a/Code/source/DesignExtractor.cpp
+++ b/Code/source/DesignExtractor.cpp
@@ -111,7 +111,7 @@ void DesignExtractor::processModifiesContainers()
 		int currLine = i;
 		unordered_set<int> descendents = pkb.getDescendants(currLine);
 		for (int descendent : descendents) {
-			unordered_set<string> modifiedList = pkb.getModifiedVar(descendent);
+			unordered_set<string> modifiedList = pkb.getVarModifiedByStm(descendent);
 			for (string modifiedVar : modifiedList) {
 				pkb.addModifiesStm(currLine, modifiedVar);
 			}

--- a/Code/source/DesignExtractor.cpp
+++ b/Code/source/DesignExtractor.cpp
@@ -25,7 +25,7 @@ void DesignExtractor::processFollowStar()
 	//Process stmt list s where Follow*(index, s) is true
 	for (int i = stmtNum; i >= 1; i--) {
 		int currStmt = i;
-		int directFollowStm = pkb.getNxtStm(currStmt);
+		int directFollowStm = pkb.getFollower(currStmt);
 		//Has a Next Stm
 		if (directFollowStm != 0) {
 			unordered_set<int> followedByStar = pkb.getAllFollowing(directFollowStm);
@@ -37,7 +37,7 @@ void DesignExtractor::processFollowStar()
 	//Process stmt list s where Follow*(s, index) is true
 	for (int i = 1; i <= stmtNum; i++) {
 		int currStmt = i;
-		int directPrvStm = pkb.getPrvStm(currStmt);
+		int directPrvStm = pkb.getStmFollowedBy(currStmt);
 
 		//If have Prev Stm
 		if (directPrvStm != 0) {
@@ -63,7 +63,7 @@ void DesignExtractor::processParentStar()
 
 		//If have parent,
 		if (directParentStm != 0) {
-			unordered_set<int> ancestors = pkb.getAllAncestors(directParentStm);
+			unordered_set<int> ancestors = pkb.getAncestors(directParentStm);
 			ancestors.insert(directParentStm);
 			pkb.setAncestors(i, ancestors);
 		}
@@ -78,7 +78,7 @@ void DesignExtractor::processParentStar()
 		//Has a Child Stm
 		if (!directChildStm.empty()) {
 			for (int childStm : directChildStm) {
-				unordered_set<int> descendents = pkb.getAllDescendants(childStm);
+				unordered_set<int> descendents = pkb.getDescendants(childStm);
 				for (int descendent : descendents) {
 					allDescendents.insert(descendent);
 				}
@@ -109,11 +109,11 @@ void DesignExtractor::processModifiesContainers()
 
 	for (int i = stmtNum; i >= 1; i--) {
 		int currLine = i;
-		unordered_set<int> descendents = pkb.getAllDescendants(currLine);
+		unordered_set<int> descendents = pkb.getDescendants(currLine);
 		for (int descendent : descendents) {
 			unordered_set<string> modifiedList = pkb.getModifiedVar(descendent);
 			for (string modifiedVar : modifiedList) {
-				pkb.addModifies(currLine, modifiedVar);
+				pkb.addModifiesStm(currLine, modifiedVar);
 			}
 		}
 	}
@@ -129,11 +129,11 @@ void DesignExtractor::processUsesContainers()
 
 	for (int i = stmtNum; i >= 1; i--) {
 		int currLine = i;
-		unordered_set<int> descendents = pkb.getAllDescendants(currLine);
+		unordered_set<int> descendents = pkb.getDescendants(currLine);
 		for (int descendent : descendents) {
-			unordered_set<string> usedList = pkb.getUsedVar(descendent);
+			unordered_set<string> usedList = pkb.getVarUsedByStm(descendent);
 			for (string usedVariable : usedList) {
-				pkb.addUses(currLine, usedVariable);
+				pkb.addUsesStm(currLine, usedVariable);
 			}
 		}
 	}

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -5,7 +5,6 @@ unordered_set< pair<int, int>, intPairhash> FollowStorage::followPairList;
 unordered_set< pair<int, int>, intPairhash> FollowStorage::follow_S_PairList;
 unordered_set<int> FollowStorage::followerList;
 unordered_set<int> FollowStorage::followedList;
-unordered_set<int> FollowStorage::rootList;
 
 FollowStorage::FollowStorage()
 {
@@ -40,11 +39,7 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 	}
 
 	// if followed is a new statement
-	if (followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
-	{
-		rootList.emplace(followed);
-	}
-	else
+	if (!followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
 	{
 		followTable.find(followed)->second.next = follower;
 	}
@@ -53,16 +48,6 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 	if (!followTable.emplace(follower, fRelationships{ followed, 0, {}, {} }).second)
 	{
 		followTable.find(follower)->second.previous = followed;
-		if (rootList.find(follower) != rootList.end())	//if follower was a root
-		{
-			rootList.erase(follower);
-			int root = followed;
-			while (followTable.find(root)->second.previous != 0)	//while root has a previous statement
-			{
-				root = followTable.find(root)->second.previous;
-			}
-			rootList.emplace(root);
-		}
 	}
 
 	followedList.emplace(followed);
@@ -195,7 +180,4 @@ unordered_set<pair<int, int>, intPairhash> FollowStorage::getF_S_PairList()
 	return follow_S_PairList;
 }
 
-unordered_set<int> FollowStorage::getRoots()
-{
-	return rootList;
 }

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -16,7 +16,7 @@ FollowStorage::FollowStorage()
 						2) the followed statement has another follower stored
 						3) the follower is following another statement
 */
-bool FollowStorage::addFollowPair(int followed, int follower)
+bool FollowStorage::addFollow(int followed, int follower)
 {
 	// if follows Pair is already added
 	if (!followPairList.emplace(pair<int, int>(followed, follower)).second)

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -10,12 +10,6 @@ FollowStorage::FollowStorage()
 {
 }
 
-/*
-	Adds the follows relation into the various lists in the storage
-	Returns false if	1) the pair is already stored
-						2) the followed statement has another follower stored
-						3) the follower is following another statement
-*/
 bool FollowStorage::addFollow(int followed, int follower)
 {
 	// if follows Pair is already added
@@ -55,11 +49,6 @@ bool FollowStorage::addFollow(int followed, int follower)
 	return true;
 }
 
-/*
-	Sets "allFollowers" of 'followed'
-	Each followed - follower pair is entered into followStarPairList
-	If 'followed' already has a list of followers, it is not replaced and it return false
-*/
 bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 {
 	if (followTable.find(followed)->second.allFollowers.size() != 0)
@@ -76,11 +65,6 @@ bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 	return true;
 }
 
-/*
-	Sets "allFollowed" of 'follower'
-	Each followed - follower pair is entered into followStarPairList
-	If 'follower' already has a list of followed, it is not replaced and it return false
-*/
 bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 {
 	if (followTable.find(follower)->second.allFollowed.size() != 0)
@@ -97,22 +81,16 @@ bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 	return true;
 }
 
-// returns true if followTable is empty
 bool FollowStorage::isEmpty()
 {
 	return followTable.size() == 0;
 }
 
-// returns true if the specified follows* pair is found
 bool FollowStorage::hasFollowStarPair(pair<int, int> pair)
 {
 	return followStarPairList.find(pair) != followStarPairList.end();
 }
 
-/*
-	return the statement following 'stm'
-	return 0 if 'stm' is not found
-*/
 int FollowStorage::getFollower(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
@@ -122,10 +100,6 @@ int FollowStorage::getFollower(int stm)
 	return 0;
 }
 
-/*
-	return the statement followed by 'stm'
-	return 0 if 'stm' is not found
-*/
 int FollowStorage::getStmFollowedBy(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
@@ -135,10 +109,6 @@ int FollowStorage::getStmFollowedBy(int stm)
 	return 0;
 }
 
-/*
-	return a list of statements that is directly/indirectly following 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> FollowStorage::getAllFollowing(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
@@ -148,10 +118,6 @@ unordered_set<int> FollowStorage::getAllFollowing(int stm)
 	return {};
 }
 
-/*
-	return a list of statements that is directly/indirectly followed by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
@@ -161,25 +127,21 @@ unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 	return {};
 }
 
-// returns a list of all statements that follows another
 unordered_set<int> FollowStorage::getAllFollowers()
 {
 	return followerList;
 }
 
-// returns a list of all statements that is followed by another
 unordered_set<int> FollowStorage::getAllFollowed()
 {
 	return followedList;
 }
 
-// returns a list of all follows pairs
 unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowPairs()
 {
 	return followPairList;
 }
 
-// returns a list of all follows* pairs
 unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowStarPairs()
 {
 	return followStarPairList;

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -2,7 +2,7 @@
 
 unordered_map<int, fRelationships> FollowStorage::followTable;
 unordered_set< pair<int, int>, intPairhash> FollowStorage::followPairList;
-unordered_set< pair<int, int>, intPairhash> FollowStorage::follow_S_PairList;
+unordered_set< pair<int, int>, intPairhash> FollowStorage::followStarPairList;
 unordered_set<int> FollowStorage::followerList;
 unordered_set<int> FollowStorage::followedList;
 
@@ -25,14 +25,14 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 	}
 
 	if (followTable.find(followed) != followTable.end() &&
-		followTable.find(followed)->second.next != 0)
+		followTable.find(followed)->second.follower != 0)
 	{
 		followPairList.erase(pair<int, int>(followed, follower));
 		return false;
 	}
 
 	if (followTable.find(follower) != followTable.end() &&
-		followTable.find(follower)->second.previous != 0)
+		followTable.find(follower)->second.followed != 0)
 	{
 		followPairList.erase(pair<int, int>(followed, follower));
 		return false;
@@ -41,13 +41,13 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 	// if followed is a new statement
 	if (!followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
 	{
-		followTable.find(followed)->second.next = follower;
+		followTable.find(followed)->second.follower = follower;
 	}
 
 	// if follower is a not new statement
 	if (!followTable.emplace(follower, fRelationships{ followed, 0, {}, {} }).second)
 	{
-		followTable.find(follower)->second.previous = followed;
+		followTable.find(follower)->second.followed = followed;
 	}
 
 	followedList.emplace(followed);
@@ -56,43 +56,43 @@ bool FollowStorage::addFollowPair(int followed, int follower)
 }
 
 /*
-	Sets "allNext" of followed
-	Each followed - follower pair is entered into follow_S_PairList
+	Sets "allFollowers" of followed
+	Each followed - follower pair is entered into followStarPairList
 	If followed already has a list of followers, it is not replaced and it return false
 */
 bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 {
-	if (followTable.find(followed)->second.allNext.size() != 0)
+	if (followTable.find(followed)->second.allFollowers.size() != 0)
 	{
 		return false;
 	}
 
-	followTable.find(followed)->second.allNext = followers;
+	followTable.find(followed)->second.allFollowers = followers;
 
 	for (auto itr = followers.cbegin(); itr != followers.cend(); ++itr)
 	{
-		follow_S_PairList.emplace(pair<int, int>(followed, *itr));
+		followStarPairList.emplace(pair<int, int>(followed, *itr));
 	}
 	return true;
 }
 
 /*
-	Sets "allPrevious" of follower
-	Each followed - follower pair is entered into follow_S_PairList
+	Sets "allFollowed" of follower
+	Each followed - follower pair is entered into followStarPairList
 	If follower already has a list of followed, it is not replaced and it return false
 */
 bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 {
-	if (followTable.find(follower)->second.allPrevious.size() != 0)
+	if (followTable.find(follower)->second.allFollowed.size() != 0)
 	{
 		return false;
 	}
 
-	followTable.find(follower)->second.allPrevious = followed;
+	followTable.find(follower)->second.allFollowed = followed;
 
 	for (auto itr = followed.cbegin(); itr != followed.cend(); ++itr)
 	{
-		follow_S_PairList.emplace(pair<int, int>(*itr, follower));
+		followStarPairList.emplace(pair<int, int>(*itr, follower));
 	}
 	return true;
 }
@@ -103,20 +103,20 @@ bool FollowStorage::isEmpty()
 }
 
 // returns true if follows* pair is found
-bool FollowStorage::containsFSPair(pair<int, int> pair)
+bool FollowStorage::hasFollowStarPair(pair<int, int> pair)
 {
-	return follow_S_PairList.find(pair) != follow_S_PairList.end();
+	return followStarPairList.find(pair) != followStarPairList.end();
 }
 
 /*
 	return the statement following the statement specified
 	return 0 if 'stm' is not found
 */
-int FollowStorage::getNextOf(int stm)
+int FollowStorage::getFollower(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
 	{
-		return followTable.at(stm).next;
+		return followTable.at(stm).follower;
 	}
 	return 0;
 }
@@ -125,11 +125,11 @@ int FollowStorage::getNextOf(int stm)
 	return the statement followed by the statement specified
 	return 0 if 'stm' is not found
 */
-int FollowStorage::getPrevOf(int stm)
+int FollowStorage::getStmFollowedBy(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
 	{
-		return followTable.at(stm).previous;
+		return followTable.at(stm).followed;
 	}
 	return 0;
 }
@@ -142,7 +142,7 @@ unordered_set<int> FollowStorage::getAllFollowing(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
 	{
-		return followTable.at(stm).allNext;
+		return followTable.at(stm).allFollowers;
 	}
 	return {};
 }
@@ -155,29 +155,27 @@ unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 {
 	if (followTable.find(stm) != followTable.end())
 	{
-		return followTable.at(stm).allPrevious;
+		return followTable.at(stm).allFollowed;
 	}
 	return {};
 }
 
-unordered_set<int> FollowStorage::getFollowerList()
+unordered_set<int> FollowStorage::getAllFollowers()
 {
 	return followerList;
 }
 
-unordered_set<int> FollowStorage::getFollowedList()
+unordered_set<int> FollowStorage::getAllFollowed()
 {
 	return followedList;
 }
 
-unordered_set<pair<int, int>, intPairhash> FollowStorage::getFPairList()
+unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowPairs()
 {
 	return followPairList;
 }
 
-unordered_set<pair<int, int>, intPairhash> FollowStorage::getF_S_PairList()
+unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowStarPairs()
 {
-	return follow_S_PairList;
-}
-
+	return followStarPairList;
 }

--- a/Code/source/FollowStorage.cpp
+++ b/Code/source/FollowStorage.cpp
@@ -38,13 +38,13 @@ bool FollowStorage::addFollow(int followed, int follower)
 		return false;
 	}
 
-	// if followed is a new statement
+	// if followed already exist in followTable
 	if (!followTable.emplace(followed, fRelationships{ 0, follower, {}, {} }).second)
 	{
 		followTable.find(followed)->second.follower = follower;
 	}
 
-	// if follower is a not new statement
+	// if follower already exist in followTable
 	if (!followTable.emplace(follower, fRelationships{ followed, 0, {}, {} }).second)
 	{
 		followTable.find(follower)->second.followed = followed;
@@ -56,9 +56,9 @@ bool FollowStorage::addFollow(int followed, int follower)
 }
 
 /*
-	Sets "allFollowers" of followed
+	Sets "allFollowers" of 'followed'
 	Each followed - follower pair is entered into followStarPairList
-	If followed already has a list of followers, it is not replaced and it return false
+	If 'followed' already has a list of followers, it is not replaced and it return false
 */
 bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 {
@@ -77,9 +77,9 @@ bool FollowStorage::setAllFollowing(int followed, unordered_set<int> followers)
 }
 
 /*
-	Sets "allFollowed" of follower
+	Sets "allFollowed" of 'follower'
 	Each followed - follower pair is entered into followStarPairList
-	If follower already has a list of followed, it is not replaced and it return false
+	If 'follower' already has a list of followed, it is not replaced and it return false
 */
 bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 {
@@ -97,19 +97,20 @@ bool FollowStorage::setAllFollowedBy(int follower, unordered_set<int> followed)
 	return true;
 }
 
+// returns true if followTable is empty
 bool FollowStorage::isEmpty()
 {
 	return followTable.size() == 0;
 }
 
-// returns true if follows* pair is found
+// returns true if the specified follows* pair is found
 bool FollowStorage::hasFollowStarPair(pair<int, int> pair)
 {
 	return followStarPairList.find(pair) != followStarPairList.end();
 }
 
 /*
-	return the statement following the statement specified
+	return the statement following 'stm'
 	return 0 if 'stm' is not found
 */
 int FollowStorage::getFollower(int stm)
@@ -122,7 +123,7 @@ int FollowStorage::getFollower(int stm)
 }
 
 /*
-	return the statement followed by the statement specified
+	return the statement followed by 'stm'
 	return 0 if 'stm' is not found
 */
 int FollowStorage::getStmFollowedBy(int stm)
@@ -135,7 +136,7 @@ int FollowStorage::getStmFollowedBy(int stm)
 }
 
 /*
-	return a list of statements that is directly/indirectly following the statement specified
+	return a list of statements that is directly/indirectly following 'stm'
 	return an empty set if 'stm' is not found
 */
 unordered_set<int> FollowStorage::getAllFollowing(int stm)
@@ -148,7 +149,7 @@ unordered_set<int> FollowStorage::getAllFollowing(int stm)
 }
 
 /*
-	return a list of statements that is directly/indirectly followed by the statement specified
+	return a list of statements that is directly/indirectly followed by 'stm'
 	return an empty set if 'stm' is not found
 */
 unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
@@ -160,21 +161,25 @@ unordered_set<int> FollowStorage::getAllFollowedBy(int stm)
 	return {};
 }
 
+// returns a list of all statements that follows another
 unordered_set<int> FollowStorage::getAllFollowers()
 {
 	return followerList;
 }
 
+// returns a list of all statements that is followed by another
 unordered_set<int> FollowStorage::getAllFollowed()
 {
 	return followedList;
 }
 
+// returns a list of all follows pairs
 unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowPairs()
 {
 	return followPairList;
 }
 
+// returns a list of all follows* pairs
 unordered_set<pair<int, int>, intPairhash> FollowStorage::getFollowStarPairs()
 {
 	return followStarPairList;

--- a/Code/source/FollowStorage.h
+++ b/Code/source/FollowStorage.h
@@ -30,7 +30,7 @@ class FollowStorage {
 public:
 	FollowStorage();
 
-	bool addFollowPair(int followed, int follower);
+	bool addFollow(int followed, int follower);
 	bool setAllFollowing(int followed, unordered_set<int> followers);
 	bool setAllFollowedBy(int follower, unordered_set<int> followed);
 

--- a/Code/source/FollowStorage.h
+++ b/Code/source/FollowStorage.h
@@ -9,18 +9,18 @@ using namespace std;
 #include "Hasher.h"
 
 /* 
-	A structure to contain:	the statement being followed directly (previous),
-							it's immediate follower (next),
-							a list of statements that being directly/indirectly followed (allPrevious),
-							a list of statements directly/indirectly following it (allNext)
+	A structure to contain:	the statement being followed directly (followed),
+							it's immediate follower (follower),
+							a list of statements that being directly/indirectly followed (allFollowed),
+							a list of statements directly/indirectly following it (allFollowers)
 	If such statement or list does not exist, it'll be set to 0 or {} respectively
 */
 struct fRelationships
 {
-	int previous;
-	int next;
-	unordered_set<int> allPrevious;
-	unordered_set<int> allNext;
+	int followed;
+	int follower;
+	unordered_set<int> allFollowed;
+	unordered_set<int> allFollowers;
 };
 
 /*
@@ -35,23 +35,21 @@ public:
 	bool setAllFollowedBy(int follower, unordered_set<int> followed);
 
 	bool isEmpty();
-	bool containsFSPair(pair<int, int> pair);
+	bool hasFollowStarPair(pair<int, int> pair);
 
-	int getNextOf(int stm);
-	int getPrevOf(int stm);
+	int getFollower(int stm);
+	int getStmFollowedBy(int stm);
 	unordered_set<int> getAllFollowing(int stm);
 	unordered_set<int> getAllFollowedBy(int stm);
-	unordered_set<int> getFollowerList();
-	unordered_set<int> getFollowedList();
-	unordered_set< pair<int, int>, intPairhash> getFPairList();
-	unordered_set< pair<int, int>, intPairhash> getF_S_PairList();
-	unordered_set<int> getRoots();
+	unordered_set<int> getAllFollowers();
+	unordered_set<int> getAllFollowed();
+	unordered_set< pair<int, int>, intPairhash> getFollowPairs();
+	unordered_set< pair<int, int>, intPairhash> getFollowStarPairs();
 
 private:
 	static unordered_map<int, fRelationships> followTable;
 	static unordered_set< pair<int, int>, intPairhash> followPairList;
-	static unordered_set< pair<int, int>, intPairhash> follow_S_PairList;
+	static unordered_set< pair<int, int>, intPairhash> followStarPairList;
 	static unordered_set<int> followerList;
 	static unordered_set<int> followedList;
-	static unordered_set<int> rootList;
 };

--- a/Code/source/FollowStorage.h
+++ b/Code/source/FollowStorage.h
@@ -30,20 +30,68 @@ class FollowStorage {
 public:
 	FollowStorage();
 
+	/*
+		Adds the follows relation into the various lists in the storage
+		Returns false if	1) the pair is already stored
+							2) the followed statement has another follower stored
+							3) the follower is following another statement
+	*/
 	bool addFollow(int followed, int follower);
+
+	/*
+		Sets "allFollowers" of 'followed'
+		Each followed - follower pair is entered into followStarPairList
+		If 'followed' already has a list of followers, it is not replaced and it return false
+	*/
 	bool setAllFollowing(int followed, unordered_set<int> followers);
+
+	/*
+		Sets "allFollowed" of 'follower'
+		Each followed - follower pair is entered into followStarPairList
+		If 'follower' already has a list of followed, it is not replaced and it return false
+	*/
 	bool setAllFollowedBy(int follower, unordered_set<int> followed);
 
+	// returns true if followTable is empty
 	bool isEmpty();
+
+	// returns true if the specified follows* pair is found
 	bool hasFollowStarPair(pair<int, int> pair);
 
+	/*
+		return the statement following 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getFollower(int stm);
+
+	/*
+		return the statement followed by 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getStmFollowedBy(int stm);
+
+	/*
+		return a list of statements that is directly/indirectly following 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAllFollowing(int stm);
+
+	/*
+		return a list of statements that is directly/indirectly followed by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAllFollowedBy(int stm);
+
+	// returns a list of all statements that follows another
 	unordered_set<int> getAllFollowers();
+
+	// returns a list of all statements that is followed by another
 	unordered_set<int> getAllFollowed();
+
+	// returns a list of all follows pairs
 	unordered_set< pair<int, int>, intPairhash> getFollowPairs();
+
+	// returns a list of all follows* pairs
 	unordered_set< pair<int, int>, intPairhash> getFollowStarPairs();
 
 private:

--- a/Code/source/ModifyStorage.cpp
+++ b/Code/source/ModifyStorage.cpp
@@ -11,6 +11,10 @@ ModifyStorage::ModifyStorage()
 {
 }
 
+/*
+	add the Modifies relation for a statement into the relevant lists and maps in the storage
+	Returns false if the pair is already exist
+*/
 bool ModifyStorage::addModifiesStm(int stm, string variable)
 {
 	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
@@ -32,6 +36,10 @@ bool ModifyStorage::addModifiesStm(int stm, string variable)
 	return true;
 }
 
+/*
+	add the Modifies relation for a procedure into the relevant lists and maps in the storage
+	Returns false if the pair is already exist
+*/
 bool ModifyStorage::addModifiesProc(string procedure, string variable)
 {
 	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
@@ -53,16 +61,22 @@ bool ModifyStorage::addModifiesProc(string procedure, string variable)
 	return true;
 }
 
+// returns true if the specified <statement, variable> pair is found
 bool ModifyStorage::containsStmVarPair(pair<int, string> pair)
 {
 	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
+// returns true if the specified <procedure, variable> pair is found
 bool ModifyStorage::containsProcVarPair(pair<string, string> pair)
 {
 	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
+/*
+	return the list of variables that is modified by 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<string> ModifyStorage::getVarModifiedByStm(int stm)
 {
 	if (stmToVarMap.find(stm) != stmToVarMap.end())
@@ -72,6 +86,10 @@ unordered_set<string> ModifyStorage::getVarModifiedByStm(int stm)
 	return {};
 }
 
+/*
+	return the list of variables that is modified by 'procedure'
+	return an empty set if 'procedure' is not found
+*/
 unordered_set<string> ModifyStorage::getVarModifiedByProc(string proc)
 {
 	if (procToVarMap.find(proc) != procToVarMap.end())
@@ -81,6 +99,10 @@ unordered_set<string> ModifyStorage::getVarModifiedByProc(string proc)
 	return {};
 }
 
+/*
+	return the list of statements that is modifying 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<int> ModifyStorage::getStmModifying(string variable)
 {
 	if (varToStmMap.find(variable) != varToStmMap.end())
@@ -90,6 +112,10 @@ unordered_set<int> ModifyStorage::getStmModifying(string variable)
 	return {};
 }
 
+/*
+	return the list of procedures that is modifying 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<string> ModifyStorage::getProcModifying(string variable)
 {
 	if (varToProcMap.find(variable) != varToProcMap.end())
@@ -99,11 +125,13 @@ unordered_set<string> ModifyStorage::getProcModifying(string variable)
 	return {};
 }
 
+// returns a list of all Modifies pairs for statements
 unordered_set<pair<int, string>, intStringhash> ModifyStorage::getStmVarPairs()
 {
 	return stmVarPairList;
 }
 
+// returns a list of all Modifies pairs for procedures
 unordered_set<pair<string, string>, strPairhash> ModifyStorage::getProcVarPairs()
 {
 	return procVarPairList;

--- a/Code/source/ModifyStorage.cpp
+++ b/Code/source/ModifyStorage.cpp
@@ -11,10 +11,6 @@ ModifyStorage::ModifyStorage()
 {
 }
 
-/*
-	add the Modifies relation for a statement into the relevant lists and maps in the storage
-	Returns false if the pair is already exist
-*/
 bool ModifyStorage::addModifiesStm(int stm, string variable)
 {
 	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
@@ -36,10 +32,6 @@ bool ModifyStorage::addModifiesStm(int stm, string variable)
 	return true;
 }
 
-/*
-	add the Modifies relation for a procedure into the relevant lists and maps in the storage
-	Returns false if the pair is already exist
-*/
 bool ModifyStorage::addModifiesProc(string procedure, string variable)
 {
 	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
@@ -61,22 +53,16 @@ bool ModifyStorage::addModifiesProc(string procedure, string variable)
 	return true;
 }
 
-// returns true if the specified <statement, variable> pair is found
 bool ModifyStorage::containsStmVarPair(pair<int, string> pair)
 {
 	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
-// returns true if the specified <procedure, variable> pair is found
 bool ModifyStorage::containsProcVarPair(pair<string, string> pair)
 {
 	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
-/*
-	return the list of variables that is modified by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<string> ModifyStorage::getVarModifiedByStm(int stm)
 {
 	if (stmToVarMap.find(stm) != stmToVarMap.end())
@@ -86,10 +72,6 @@ unordered_set<string> ModifyStorage::getVarModifiedByStm(int stm)
 	return {};
 }
 
-/*
-	return the list of variables that is modified by 'procedure'
-	return an empty set if 'procedure' is not found
-*/
 unordered_set<string> ModifyStorage::getVarModifiedByProc(string proc)
 {
 	if (procToVarMap.find(proc) != procToVarMap.end())
@@ -99,10 +81,6 @@ unordered_set<string> ModifyStorage::getVarModifiedByProc(string proc)
 	return {};
 }
 
-/*
-	return the list of statements that is modifying 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<int> ModifyStorage::getStmModifying(string variable)
 {
 	if (varToStmMap.find(variable) != varToStmMap.end())
@@ -112,10 +90,6 @@ unordered_set<int> ModifyStorage::getStmModifying(string variable)
 	return {};
 }
 
-/*
-	return the list of procedures that is modifying 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<string> ModifyStorage::getProcModifying(string variable)
 {
 	if (varToProcMap.find(variable) != varToProcMap.end())
@@ -125,13 +99,11 @@ unordered_set<string> ModifyStorage::getProcModifying(string variable)
 	return {};
 }
 
-// returns a list of all Modifies pairs for statements
 unordered_set<pair<int, string>, intStringhash> ModifyStorage::getStmVarPairs()
 {
 	return stmVarPairList;
 }
 
-// returns a list of all Modifies pairs for procedures
 unordered_set<pair<string, string>, strPairhash> ModifyStorage::getProcVarPairs()
 {
 	return procVarPairList;

--- a/Code/source/ModifyStorage.cpp
+++ b/Code/source/ModifyStorage.cpp
@@ -1,110 +1,110 @@
 #include "ModifyStorage.h"
 
-unordered_set<pair<int, string>, intStringhash> ModifyStorage::stmVarPairs;
-unordered_set<pair<string, string>, strPairhash> ModifyStorage::procVarPairs;
-unordered_map<int, unordered_set<string>> ModifyStorage::varList_Stm;
-unordered_map<string, unordered_set<string>> ModifyStorage::varList_Proc;
-unordered_map<string, unordered_set<int> > ModifyStorage::stmLists;
-unordered_map<string, unordered_set<string> > ModifyStorage::procLists;
+unordered_set<pair<int, string>, intStringhash> ModifyStorage::stmVarPairList;
+unordered_set<pair<string, string>, strPairhash> ModifyStorage::procVarPairList;
+unordered_map<int, unordered_set<string>> ModifyStorage::stmToVarMap;
+unordered_map<string, unordered_set<string>> ModifyStorage::procToVarMap;
+unordered_map<string, unordered_set<int> > ModifyStorage::varToStmMap;
+unordered_map<string, unordered_set<string> > ModifyStorage::varToProcMap;
 
 ModifyStorage::ModifyStorage()
 {
 }
 
-bool ModifyStorage::addModifies(int stm, string variable)
+bool ModifyStorage::addModifiesStm(int stm, string variable)
 {
-	if (!stmVarPairs.emplace(pair<int, string>(stm, variable)).second)
+	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
 	{
 		return false;
 	}
-	if (!varList_Stm.emplace(stm, unordered_set<string>{ variable }).second)
+	if (!stmToVarMap.emplace(stm, unordered_set<string>{ variable }).second)
 	{
-		varList_Stm.at(stm).emplace(variable);
+		stmToVarMap.at(stm).emplace(variable);
 	}
-	if (!stmLists.emplace(variable, unordered_set<int>{ stm }).second)
+	if (!varToStmMap.emplace(variable, unordered_set<int>{ stm }).second)
 	{
-		stmLists.at(variable).emplace(stm);
+		varToStmMap.at(variable).emplace(stm);
 	}
-	if (!stmLists.emplace("", unordered_set<int>{ stm }).second)
+	if (!varToStmMap.emplace("", unordered_set<int>{ stm }).second)
 	{
-		stmLists.at("").emplace(stm);
+		varToStmMap.at("").emplace(stm);
 	}
 	return true;
 }
 
-bool ModifyStorage::addModifies(string procedure, string variable)
+bool ModifyStorage::addModifiesProc(string procedure, string variable)
 {
-	if (!procVarPairs.emplace(pair<string, string>(procedure, variable)).second)
+	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
 	{
 		return false;
 	}
-	if (!varList_Proc.emplace(procedure, unordered_set<string>{ variable }).second)
+	if (!procToVarMap.emplace(procedure, unordered_set<string>{ variable }).second)
 	{
-		varList_Proc.at(procedure).emplace(variable);
+		procToVarMap.at(procedure).emplace(variable);
 	}
-	if (!procLists.emplace(variable, unordered_set<string>{ procedure }).second)
+	if (!varToProcMap.emplace(variable, unordered_set<string>{ procedure }).second)
 	{
-		procLists.at(variable).emplace(procedure);
+		varToProcMap.at(variable).emplace(procedure);
 	}
-	if (!procLists.emplace("", unordered_set<string>{ procedure }).second)
+	if (!varToProcMap.emplace("", unordered_set<string>{ procedure }).second)
 	{
-		procLists.at("").emplace(procedure);
+		varToProcMap.at("").emplace(procedure);
 	}
 	return true;
 }
 
 bool ModifyStorage::containsStmVarPair(pair<int, string> pair)
 {
-	return stmVarPairs.find(pair) != stmVarPairs.end();
+	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
 bool ModifyStorage::containsProcVarPair(pair<string, string> pair)
 {
-	return procVarPairs.find(pair) != procVarPairs.end();
+	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
-unordered_set<string> ModifyStorage::getVarModifiedBy(int stm)
+unordered_set<string> ModifyStorage::getVarModifiedByStm(int stm)
 {
-	if (varList_Stm.find(stm) != varList_Stm.end())
+	if (stmToVarMap.find(stm) != stmToVarMap.end())
 	{
-		return varList_Stm.at(stm);
+		return stmToVarMap.at(stm);
 	}
 	return {};
 }
 
-unordered_set<string> ModifyStorage::getVarModifiedBy(string proc)
+unordered_set<string> ModifyStorage::getVarModifiedByProc(string proc)
 {
-	if (varList_Proc.find(proc) != varList_Proc.end())
+	if (procToVarMap.find(proc) != procToVarMap.end())
 	{
-		return varList_Proc.at(proc);
+		return procToVarMap.at(proc);
 	}
 	return {};
 }
 
 unordered_set<int> ModifyStorage::getStmModifying(string variable)
 {
-	if (stmLists.find(variable) != stmLists.end())
+	if (varToStmMap.find(variable) != varToStmMap.end())
 	{
-		return stmLists.at(variable);
+		return varToStmMap.at(variable);
 	}
 	return {};
 }
 
 unordered_set<string> ModifyStorage::getProcModifying(string variable)
 {
-	if (procLists.find(variable) != procLists.end())
+	if (varToProcMap.find(variable) != varToProcMap.end())
 	{
-		procLists.at(variable);
+		varToProcMap.at(variable);
 	}
 	return {};
 }
 
 unordered_set<pair<int, string>, intStringhash> ModifyStorage::getStmVarPairs()
 {
-	return stmVarPairs;
+	return stmVarPairList;
 }
 
 unordered_set<pair<string, string>, strPairhash> ModifyStorage::getProcVarPairs()
 {
-	return procVarPairs;
+	return procVarPairList;
 }

--- a/Code/source/ModifyStorage.h
+++ b/Code/source/ModifyStorage.h
@@ -17,23 +17,23 @@ class ModifyStorage
 public:
 	ModifyStorage();
 
-	bool addModifies(int stm, string variable);
-	bool addModifies(string procedure, string variable);
+	bool addModifiesStm(int stm, string variable);
+	bool addModifiesProc(string procedure, string variable);
 
 	bool containsStmVarPair(pair<int, string> pair);
 	bool containsProcVarPair(pair<string, string> pair);
-	unordered_set<string> getVarModifiedBy(int stm);
-	unordered_set<string> getVarModifiedBy(string proc);
+	unordered_set<string> getVarModifiedByStm(int stm);
+	unordered_set<string> getVarModifiedByProc(string proc);
 	unordered_set<int> getStmModifying(string variable);
 	unordered_set<string> getProcModifying(string variable);
 	unordered_set< pair<int, string>, intStringhash> getStmVarPairs();
 	unordered_set< pair<string, string>, strPairhash> getProcVarPairs();
 
 private:
-	static unordered_set<pair<int, string>, intStringhash> stmVarPairs;
-	static unordered_set<pair<string, string>, strPairhash> procVarPairs;
-	static unordered_map<int, unordered_set<string>> varList_Stm;
-	static unordered_map<string, unordered_set<string>> varList_Proc;
-	static unordered_map<string, unordered_set<int> > stmLists;
-	static unordered_map<string, unordered_set<string> > procLists;
+	static unordered_set<pair<int, string>, intStringhash> stmVarPairList;
+	static unordered_set<pair<string, string>, strPairhash> procVarPairList;
+	static unordered_map<int, unordered_set<string>> stmToVarMap;
+	static unordered_map<string, unordered_set<string>> procToVarMap;
+	static unordered_map<string, unordered_set<int> > varToStmMap;
+	static unordered_map<string, unordered_set<string> > varToProcMap;
 };

--- a/Code/source/ModifyStorage.h
+++ b/Code/source/ModifyStorage.h
@@ -17,16 +17,52 @@ class ModifyStorage
 public:
 	ModifyStorage();
 
+	/*
+		add the Modifies relation for a statement into the relevant lists and maps in the storage
+		Returns false if the pair is already exist
+	*/
 	bool addModifiesStm(int stm, string variable);
+
+	/*
+		add the Modifies relation for a procedure into the relevant lists and maps in the storage
+		Returns false if the pair is already exist
+	*/
 	bool addModifiesProc(string procedure, string variable);
 
+	// returns true if the specified <statement, variable> pair is found
 	bool containsStmVarPair(pair<int, string> pair);
+
+	// returns true if the specified <procedure, variable> pair is found
 	bool containsProcVarPair(pair<string, string> pair);
+
+	/*
+		return the list of variables that is modified by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<string> getVarModifiedByStm(int stm);
+
+	/*
+		return the list of variables that is modified by 'procedure'
+		return an empty set if 'procedure' is not found
+	*/
 	unordered_set<string> getVarModifiedByProc(string proc);
+
+	/*
+		return the list of statements that is modifying 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<int> getStmModifying(string variable);
+
+	/*
+		return the list of procedures that is modifying 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<string> getProcModifying(string variable);
+
+	// returns a list of all Modifies pairs for statements
 	unordered_set< pair<int, string>, intStringhash> getStmVarPairs();
+
+	// returns a list of all Modifies pairs for procedures
 	unordered_set< pair<string, string>, strPairhash> getProcVarPairs();
 
 private:

--- a/Code/source/ModifyStorage.h
+++ b/Code/source/ModifyStorage.h
@@ -36,25 +36,27 @@ public:
 	bool containsProcVarPair(pair<string, string> pair);
 
 	/*
-		return the list of variables that is modified by 'stm'
+		return a list of variables that is modified by 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<string> getVarModifiedByStm(int stm);
 
 	/*
-		return the list of variables that is modified by 'procedure'
+		return a list of variables that is modified by 'procedure'
 		return an empty set if 'procedure' is not found
 	*/
 	unordered_set<string> getVarModifiedByProc(string proc);
 
 	/*
-		return the list of statements that is modifying 'variable'
+		return a list of statements that modifies 'variable'
+		returns a list of all statements that modifies a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<int> getStmModifying(string variable);
 
 	/*
-		return the list of procedures that is modifying 'variable'
+		return a list of procedures that modifies 'variable'
+		returns a list of all procedures that modifies a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<string> getProcModifying(string variable);

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -67,7 +67,7 @@ bool PKB::addFollow(int stm1, int stm2)
 	{
 		return false;
 	}
-	return fStore.addFollowPair(stm1, stm2);
+	return fStore.addFollow(stm1, stm2);
 }
 
 bool PKB::setFollowers(int stm, unordered_set<int> stmList)

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -387,20 +387,20 @@ unordered_set<pair<string, string>, strPairhash> PKB::getProcVarModifyPairs()
 	If isExclusive is true, the function finds for an exact match to the specfied expression.
 	If false, it finds for a matching substring instead.
 */
-vector<int> PKB::findPattern(string variable, string expr, bool isExclusive)
+unordered_set<int> PKB::findPattern(string variable, string expr, bool isExclusive)
 {
-	vector<int> validStm;
+	unordered_set<int> validStm;
 	for each (const auto elem in patternList)
 	{
 		if (elem.second.first.compare(variable) == 0)
 		{
 			if (isExclusive && elem.second.second.compare(expr) == 0)
 			{
-				validStm.push_back(elem.first);
+				validStm.emplace(elem.first);
 			}
 			else if (!isExclusive && elem.second.second.find(expr) != string::npos)
 			{
-				validStm.push_back(elem.first);
+				validStm.emplace(elem.first);
 			}
 		}
 	}
@@ -413,18 +413,18 @@ vector<int> PKB::findPattern(string variable, string expr, bool isExclusive)
 	If isExclusive is true, the function finds for an exact match to the specfied expression.
 	If false, it finds for a matching substring instead.
 */
-vector<int> PKB::findPattern(string expr, bool isExclusive)
+unordered_set<int> PKB::findPattern(string expr, bool isExclusive)
 {
-	vector<int> validStm;
+	unordered_set<int> validStm;
 	for each (const auto elem in patternList)
 	{
 		if (isExclusive && elem.second.second.compare(expr) == 0)
 		{
-			validStm.push_back(elem.first);
+			validStm.emplace(elem.first);
 		}
 		else if (!isExclusive && elem.second.second.find(expr) != string::npos)
 		{
-			validStm.push_back(elem.first);
+			validStm.emplace(elem.first);
 		}
 	}
 	return validStm;
@@ -436,18 +436,18 @@ vector<int> PKB::findPattern(string expr, bool isExclusive)
 	If isExclusive is true, the function finds for an exact match to the specfied expression.
 	If false, it finds for a matching substring instead.
 */
-vector<pair<int, string>> PKB::findPatternPairs(string expr, bool isExclusive)
+unordered_set<pair<int, string>, intStringhash> PKB::findPatternPairs(string expr, bool isExclusive)
 {
-	vector<pair<int, string>> validPairs;
+	unordered_set<pair<int, string>, intStringhash> validPairs;
 	for each (const auto elem in patternList)
 	{
 		if (isExclusive && elem.second.second.compare(expr) == 0)
 		{
-			validPairs.push_back(pair<int, string>(elem.first, elem.second.first));
+			validPairs.emplace(pair<int, string>(elem.first, elem.second.first));
 		}
 		else if (!isExclusive && elem.second.second.find(expr) != string::npos)
 		{
-			validPairs.push_back(pair<int, string>(elem.first, elem.second.first));
+			validPairs.emplace(pair<int, string>(elem.first, elem.second.first));
 		}
 	}
 	return validPairs;

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -1,6 +1,5 @@
 #include "PKB.h"
 
-
 string PKB::procName;
 vector<stmType> PKB::stmTypeList;
 unordered_set<string> PKB::varList;
@@ -100,40 +99,40 @@ bool PKB::setDescendants(int stm, unordered_set<int> stmList)
 	return pStore.setDescendants(stm, stmList);
 }
 
-bool PKB::addUses(int stm, string variable)
+bool PKB::addUsesStm(int stm, string variable)
 {
 	if (variable == "")
 	{
 		return false;
 	}
-	return uStore.addUses(stm, variable);
+	return uStore.addUsesStm(stm, variable);
 }
 
-bool PKB::addUses(string procedure, string variable)
+bool PKB::addUsesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
 	{
 		return false;
 	}
-	return uStore.addUses(procedure, variable);
+	return uStore.addUsesProc(procedure, variable);
 }
 
-bool PKB::addModifies(int stm, string variable)
+bool PKB::addModifiesStm(int stm, string variable)
 {
 	if (variable == "")
 	{
 		return false;
 	}
-	return mStore.addModifies(stm, variable);
+	return mStore.addModifiesStm(stm, variable);
 }
 
-bool PKB::addModifies(string procedure, string variable)
+bool PKB::addModifiesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
 	{
 		return false;
 	}
-	return mStore.addModifies(procedure, variable);
+	return mStore.addModifiesProc(procedure, variable);
 }
 
 bool PKB::addAssign(int stm, string variable, string expr)
@@ -196,19 +195,19 @@ bool PKB::hasFollowRelation()
 	return !fStore.isEmpty();
 }
 
-bool PKB::hasFollow_S_Pair(int stm1, int stm2)
+bool PKB::hasFollowStarPair(int stm1, int stm2)
 {
-	return fStore.containsFSPair(pair<int, int>(stm1, stm2));
+	return fStore.hasFollowStarPair(pair<int, int>(stm1, stm2));
 }
 
-int PKB::getPrvStm(int stm)
+int PKB::getStmFollowedBy(int stm)
 {
-	return fStore.getPrevOf(stm);
+	return fStore.getStmFollowedBy(stm);
 }
 
-int PKB::getNxtStm(int stm)
+int PKB::getFollower(int stm)
 {
-	return fStore.getNextOf(stm);
+	return fStore.getFollower(stm);
 }
 
 unordered_set<int> PKB::getAllFollowing(int stm)
@@ -223,27 +222,22 @@ unordered_set<int> PKB::getAllFollowedBy(int stm)
 
 unordered_set<int> PKB::getAllFollowers()
 {
-	return fStore.getFollowerList();
+	return fStore.getAllFollowers();
 }
 
 unordered_set<int> PKB::getAllFollowed()
 {
-	return fStore.getFollowedList();
+	return fStore.getAllFollowed();
 }
 
 unordered_set<pair<int, int>, intPairhash> PKB::getFollowPairs()
 {
-	return fStore.getFPairList();
+	return fStore.getFollowPairs();
 }
 
-unordered_set<pair<int, int>, intPairhash> PKB::getFollow_S_Pairs()
+unordered_set<pair<int, int>, intPairhash> PKB::getFollowStarPairs()
 {
-	return fStore.getF_S_PairList();
-}
-
-unordered_set<int> PKB::getFollowRoots()
-{
-	return fStore.getRoots();
+	return fStore.getFollowStarPairs();
 }
 
 bool PKB::hasParentRelation()
@@ -263,52 +257,47 @@ bool PKB::isChild(int stm)
 
 bool PKB::hasAncDescPair(int stm1, int stm2)
 {
-	return pStore.containsAnc_Desc(pair<int, int>(stm1, stm2));
+	return pStore.hasAncDescPair(pair<int, int>(stm1, stm2));
 }
 
 int PKB::getParent(int stm)
 {
-	return pStore.getParentOf(stm);
+	return pStore.getParent(stm);
 }
 
 unordered_set<int> PKB::getChildren(int stm)
 {
-	return pStore.getChildrenOf(stm);
+	return pStore.getChildren(stm);
 }
 
-unordered_set<int> PKB::getAllAncestors(int stm)
+unordered_set<int> PKB::getAncestors(int stm)
 {
-	return pStore.getAncestorsOf(stm);
+	return pStore.getAncestors(stm);
 }
 
-unordered_set<int> PKB::getAllDescendants(int stm)
+unordered_set<int> PKB::getDescendants(int stm)
 {
-	return pStore.getDescendantsOf(stm);
+	return pStore.getDescendants(stm);
 }
 
 unordered_set<int> PKB::getAllParents()
 {
-	return pStore.getParentList();
+	return pStore.getAllParent();
 }
 
 unordered_set<int> PKB::getAllChildren()
 {
-	return pStore.getChildrenList();
+	return pStore.getAllChildren();
 }
 
 unordered_set<pair<int, int>, intPairhash> PKB::getParentChildPairs()
 {
-	return pStore.getParent_ChildList();
+	return pStore.getParentChildPairs();
 }
 
 unordered_set<pair<int, int>, intPairhash> PKB::getAncDescPairs()
 {
-	return pStore.getAnc_DescList();
-}
-
-unordered_set<int> PKB::getParentRoots()
-{
-	return pStore.getRootList();
+	return pStore.getAncDescPair();
 }
 
 bool PKB::isUsing(int stm, string variable)
@@ -321,14 +310,14 @@ bool PKB::isUsing(string procedure, string variable)
 	return uStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
-unordered_set<string> PKB::getUsedVar(int stm)
+unordered_set<string> PKB::getVarUsedByStm(int stm)
 {
-	return uStore.getVarUsedBy(stm);
+	return uStore.getVarUsedByStm(stm);
 }
 
-unordered_set<string> PKB::getUsedVar(string procedure)
+unordered_set<string> PKB::getVarUsedByProc(string procedure)
 {
-	return uStore.getVarUsedBy(procedure);
+	return uStore.getVarUsedByProc(procedure);
 }
 
 unordered_set<int> PKB::getStmUsing(string variable)
@@ -363,12 +352,12 @@ bool PKB::isModifying(string procedure, string variable)
 
 unordered_set<string> PKB::getModifiedVar(int stm)
 {
-	return mStore.getVarModifiedBy(stm);
+	return mStore.getVarModifiedByStm(stm);
 }
 
 unordered_set<string> PKB::getModifiedVar(string procedure)
 {
-	return mStore.getVarModifiedBy(procedure);
+	return mStore.getVarModifiedByProc(procedure);
 }
 
 unordered_set<int> PKB::getStmModifying(string variable)
@@ -391,6 +380,13 @@ unordered_set<pair<string, string>, strPairhash> PKB::getProcVarModifyPairs()
 	return mStore.getProcVarPairs();
 }
 
+/*
+	Search for assign statements with pattern matching
+		- the specified variable ont the left side and
+		- the specified expression on the right side
+	If isExclusive is true, the function finds for an exact match to the specfied expression.
+	If false, it finds for a matching substring instead.
+*/
 vector<int> PKB::findPattern(string variable, string expr, bool isExclusive)
 {
 	vector<int> validStm;
@@ -411,6 +407,12 @@ vector<int> PKB::findPattern(string variable, string expr, bool isExclusive)
 	return validStm;
 }
 
+/*
+	Search for assign statements with pattern matching
+		- the specified expression on the right side
+	If isExclusive is true, the function finds for an exact match to the specfied expression.
+	If false, it finds for a matching substring instead.
+*/
 vector<int> PKB::findPattern(string expr, bool isExclusive)
 {
 	vector<int> validStm;
@@ -428,6 +430,12 @@ vector<int> PKB::findPattern(string expr, bool isExclusive)
 	return validStm;
 }
 
+/*
+	Search for pairs of an assign statement and left-hand side variable with
+		the right side expression matching the specified expression
+	If isExclusive is true, the function finds for an exact match to the specfied expression.
+	If false, it finds for a matching substring instead.
+*/
 vector<pair<int, string>> PKB::findPatternPairs(string expr, bool isExclusive)
 {
 	vector<pair<int, string>> validPairs;

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -350,12 +350,12 @@ bool PKB::isModifying(string procedure, string variable)
 	return mStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
-unordered_set<string> PKB::getModifiedVar(int stm)
+unordered_set<string> PKB::getVarModifiedByStm(int stm)
 {
 	return mStore.getVarModifiedByStm(stm);
 }
 
-unordered_set<string> PKB::getModifiedVar(string procedure)
+unordered_set<string> PKB::getVarModifiedByProc(string procedure)
 {
 	return mStore.getVarModifiedByProc(procedure);
 }

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -20,13 +20,11 @@ PKB::PKB()
 {
 }
 
-// add a procedure to procList
 void PKB::addProc(string name)
 {
 	procList.emplace(name);
 }
 
-//add statement to its respective StmList and set stmTypeList[stmNo] to type 
 void PKB::addStatement(int stmNo, stmType type)
 {
 	stmTypeList.assign(stmNo, type);
@@ -53,25 +51,16 @@ void PKB::addStatement(int stmNo, stmType type)
 	}
 }
 
-// add variable to varList
 void PKB::addVariable(string name)
 {
 	varList.emplace(name);
 }
 
-// add constant to constList
 void PKB::addConstant(string value)
 {
 	constList.emplace(value);
 }
 
-/*
-	add the follows relation in FollowStorage
-	Returns false if	1) the pair is already stored
-						2) the followed statement has another follower stored
-						3) the follower is following another statement
-						4) stm2 <= stm1 or stm1, stm2 <= 0
-*/
 bool PKB::addFollow(int stm1, int stm2)
 {
 	if (stm2 <= stm1 || stm1 <= 0 || stm2 <= 0)
@@ -81,33 +70,16 @@ bool PKB::addFollow(int stm1, int stm2)
 	return fStore.addFollow(stm1, stm2);
 }
 
-/*
-	Sets the list of followers of 'stm' to be 'stmList' in FollowStorage
-	Every FollowStar pair is stored as well
-	If stm already has a list of followers, it is not replaced and it return false
-*/
 bool PKB::setAllFollowing(int stm, unordered_set<int> stmList)
 {
 	return fStore.setAllFollowing(stm, stmList);
 }
 
-/*
-	Sets the list of followed of 'stm' to be 'stmList' in FollowStorage
-	Every FollowStar pair is stored as well
-	If stm already has a list of followed, it is not replaced and it return false
-*/
 bool PKB::setAllFollowedBy(int stm, unordered_set<int> stmList)
 {
 	return fStore.setAllFollowedBy(stm, stmList);
 }
 
-
-/*
-	Adds the parent relation into the various lists in the storage
-	Returns false if	1) the pair is already stored
-						2) the child already has another parent
-						3) stm2 <= stm1 or stm1, stm2 <= 0
-*/
 bool PKB::addParent(int stm1, int stm2)
 {
 	if (stm2 <= stm1 || stm1 <= 0 || stm2 <= 0)
@@ -117,31 +89,16 @@ bool PKB::addParent(int stm1, int stm2)
 	return pStore.addParent_Child(stm1, stm2);
 }
 
-/*
-	Sets the list of ancestors of 'stm' in ParentStorage
-	Each Parent* pair is stored as well
-	If stm already has a list of ancestors, it is not replaced and it return false
-*/
 bool PKB::setAncestors(int stm, unordered_set<int> stmList)
 {
 	return pStore.setAncestors(stm, stmList);
 }
 
-/*
-	Sets the list of descendants of 'stm' in ParentStorage
-	Each Parent* pair is stored as well
-	If stm already has a list of descendants, it is not replaced and it return false
-*/
 bool PKB::setDescendants(int stm, unordered_set<int> stmList)
 {
 	return pStore.setDescendants(stm, stmList);
 }
 
-/*
-	add the Uses relation for a Statement in UseStorage
-	Returns false if	1) the pair is already stored
-						2) stm <= 0 and variable is an empty string
-*/
 bool PKB::addUsesStm(int stm, string variable)
 {
 	if (stm <= 0 || variable == "")
@@ -151,11 +108,6 @@ bool PKB::addUsesStm(int stm, string variable)
 	return uStore.addUsesStm(stm, variable);
 }
 
-/*
-	add the Uses relation for a Procedure in UseStorage
-	Returns false if	1) the pair is already stored
-						2) procedure or variable is an empty string
-*/
 bool PKB::addUsesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
@@ -165,11 +117,6 @@ bool PKB::addUsesProc(string procedure, string variable)
 	return uStore.addUsesProc(procedure, variable);
 }
 
-/*
-	add the Modifies relation for a Statement in UseStorage
-	Returns false if	1) the pair is already stored
-						2) stm <= 0 and variable is an empty string
-*/
 bool PKB::addModifiesStm(int stm, string variable)
 {
 	if (variable == "")
@@ -179,11 +126,6 @@ bool PKB::addModifiesStm(int stm, string variable)
 	return mStore.addModifiesStm(stm, variable);
 }
 
-/*
-	add the Modifies relation for a Procedure in UseStorage
-	Returns false if	1) the pair is already stored
-						2) procedure or variable is an empty string
-*/
 bool PKB::addModifiesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
@@ -193,358 +135,251 @@ bool PKB::addModifiesProc(string procedure, string variable)
 	return mStore.addModifiesProc(procedure, variable);
 }
 
-/* 
-	add a pattern for an assign statement to patternList
-	returns false if 'stm' already exist in the list with another pattern
-*/
 bool PKB::addAssignPattern(int stm, string variable, string expr)
 {
 	return patternList.emplace(stm, pair<string, string>(variable, expr)).second;
 }
 
-// returns the stored list of procedures
 unordered_set<string> PKB::getProcList()
 {
 	return procList;
 }
 
-// returns the total number of statements in the entire program
 int PKB::getTotalStmNo()
 {
 	return stmTypeList.size();
 }
 
-// return the statement type of stm
 stmType PKB::getStmType(int stm)
 {
 	return stmTypeList.at(stm);
 }
 
-// returns the stored list of read statements
 unordered_set<int> PKB::getReadStms()
 {
 	return readStmList;
 }
 
-// returns the stored list of print statements
 unordered_set<int> PKB::getPrintStms()
 {
 	return printStmList;
 }
 
-// returns the stored list of assign statements
 unordered_set<int> PKB::getAssignStms()
 {
 	return assignStmList;
 }
 
-// returns the stored list of if statements
 unordered_set<int> PKB::getIfStms()
 {
 	return ifStmList;
 }
 
-// returns the stored list of while statements
 unordered_set<int> PKB::getWhileStms()
 {
 	return whileStmList;
 }
 
-// returns the stored list of variables
 unordered_set<string> PKB::getVariables()
 {
 	return varList;
 }
 
-// returns the stored list of constants
 unordered_set<string> PKB::getConstants()
 {
 	return constList;
 }
 
-// checks if there is at least one follows relation
 bool PKB::hasFollowRelation()
 {
 	return !fStore.isEmpty();
 }
 
-// checks if the relation Follows*(stm1, stm2) exist
 bool PKB::hasFollowStarPair(int stm1, int stm2)
 {
 	return fStore.hasFollowStarPair(pair<int, int>(stm1, stm2));
 }
 
-/*
-	return the statement followed by 'stm'
-	return 0 if 'stm' is not found
-*/
 int PKB::getStmFollowedBy(int stm)
 {
 	return fStore.getStmFollowedBy(stm);
 }
 
-/*
-	return the statement following 'stm'
-	return 0 if 'stm' is not found
-*/
 int PKB::getFollower(int stm)
 {
 	return fStore.getFollower(stm);
 }
 
-/*
-	return a list of statements that is directly/indirectly following 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> PKB::getAllFollowing(int stm)
 {
 	return fStore.getAllFollowing(stm);
 }
 
-/*
-	return a list of statements that is directly/indirectly followed by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> PKB::getAllFollowedBy(int stm)
 {
 	return fStore.getAllFollowedBy(stm);
 }
 
-// returns a list of all statements that follows another
 unordered_set<int> PKB::getAllFollowers()
 {
 	return fStore.getAllFollowers();
 }
 
-// returns a list of all statements that is followed by another
 unordered_set<int> PKB::getAllFollowed()
 {
 	return fStore.getAllFollowed();
 }
 
-// returns a list of all follows pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getFollowPairs()
 {
 	return fStore.getFollowPairs();
 }
 
-// returns a list of all follows* pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getFollowStarPairs()
 {
 	return fStore.getFollowStarPairs();
 }
 
-// checks if there is at least one Parent relationship
 bool PKB::hasParentRelation()
 {
 	return !pStore.isEmpty();
 }
 
-// checks if stm is a parent of another
 bool PKB::isParent(int stm)
 {
 	return pStore.isParent(stm);
 }
 
-// checks if stm is a child of another
 bool PKB::isChild(int stm)
 {
 	return pStore.isChild(stm);
 }
 
-// checks if the relation Parent*(stm1, stm2) exist
 bool PKB::hasAncDescPair(int stm1, int stm2)
 {
 	return pStore.hasAncDescPair(pair<int, int>(stm1, stm2));
 }
 
-/*
-	return the statement that is the parent of 'stm'
-	return 0 if 'stm' is not found
-*/
 int PKB::getParent(int stm)
 {
 	return pStore.getParent(stm);
 }
 
-/*
-	return the list of statements that is the children of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> PKB::getChildren(int stm)
 {
 	return pStore.getChildren(stm);
 }
 
-/*
-	return the list of statements that is the ancestors of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> PKB::getAncestors(int stm)
 {
 	return pStore.getAncestors(stm);
 }
 
-/*
-	return the list of statements that is the descendants of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> PKB::getDescendants(int stm)
 {
 	return pStore.getDescendants(stm);
 }
 
-// returns a list of all statements that is the parent of another
 unordered_set<int> PKB::getAllParents()
 {
 	return pStore.getAllParent();
 }
 
-// returns a list of all statements that is the child of another
 unordered_set<int> PKB::getAllChildren()
 {
 	return pStore.getAllChildren();
 }
 
-// returns a list of all parent pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getParentChildPairs()
 {
 	return pStore.getParentChildPairs();
 }
 
-// returns a list of all parent* pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getAncDescPairs()
 {
 	return pStore.getAncDescPair();
 }
 
-// checks if the relation Uses(stm, variable) exist
 bool PKB::isStmUsing(int stm, string variable)
 {
 	return uStore.containsStmVarPair(pair<int, string>(stm, variable) );
 }
 
-// checks if the relation Uses(procedure, variable) exist
 bool PKB::isProcUsing(string procedure, string variable)
 {
 	return uStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
-/*
-	return the list of variables that is used by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<string> PKB::getVarUsedByStm(int stm)
 {
 	return uStore.getVarUsedByStm(stm);
 }
 
-/*
-	return the list of variables that is used by 'procedure'
-	return an empty set if 'procedure' is not found
-*/
 unordered_set<string> PKB::getVarUsedByProc(string procedure)
 {
 	return uStore.getVarUsedByProc(procedure);
 }
 
-/*
-	return the list of statements that is using 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<int> PKB::getStmUsing(string variable)
 {
 	return uStore.getStmUsing(variable);
 }
 
-/*
-	return the list of procedure that is using 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<string> PKB::getProcUsing(string variable)
 {
 	return uStore.getProcUsing(variable);
 }
 
-// returns a list of all Uses pairs for statements
 unordered_set<pair<int, string>, intStringhash> PKB::getStmVarUsePairs()
 {
 	return uStore.getStmVarPairs();
 }
 
-// returns a list of all Uses pairs for procedures
 unordered_set<pair<string, string>, strPairhash> PKB::getProcVarUsePairs()
 {
 	return uStore.getProcVarPairs();
 }
 
-// checks if the relation Modifies(stm, variable) exist
 bool PKB::isStmModifying(int stm, string variable)
 {
 	return mStore.containsStmVarPair(pair<int, string>(stm, variable));
 }
 
-// checks if the relation Modifies(procedure, variable) exist
 bool PKB::isProcModifying(string procedure, string variable)
 {
 	return mStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
-/*
-	return the list of variables that is modified by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<string> PKB::getVarModifiedByStm(int stm)
 {
 	return mStore.getVarModifiedByStm(stm);
 }
 
-/*
-	return the list of variables that is modified by 'procedure'
-	return an empty set if 'procedure' is not found
-*/
 unordered_set<string> PKB::getVarModifiedByProc(string procedure)
 {
 	return mStore.getVarModifiedByProc(procedure);
 }
 
-/*
-	return the list of statements that is modifying 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<int> PKB::getStmModifying(string variable)
 {
 	return mStore.getStmModifying(variable);
 }
 
-/*
-	return the list of procedures that is modifying 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<string> PKB::getProcModifying(string variable)
 {
 	return mStore.getProcModifying(variable);
 }
 
-// returns a list of all Modifies pairs for statements
 unordered_set<pair<int, string>, intStringhash> PKB::getStmVarModifyPairs()
 {
 	return mStore.getStmVarPairs();
 }
 
-// returns a list of all Modifies pairs for procedures
 unordered_set<pair<string, string>, strPairhash> PKB::getProcVarModifyPairs()
 {
 	return mStore.getProcVarPairs();
 }
 
-/*
-	Search for assign statements with pattern matching
-		- the specified variable ont the left side and
-		- the specified expression on the right side
-	If isExclusive is true, the function finds for an exact match to the specfied expression.
-	If false, it finds for a matching substring instead.
-*/
 unordered_set<int> PKB::findPattern(string variable, string expr, bool isExclusive)
 {
 	unordered_set<int> validStm;
@@ -565,12 +400,6 @@ unordered_set<int> PKB::findPattern(string variable, string expr, bool isExclusi
 	return validStm;
 }
 
-/*
-	Search for assign statements with pattern matching
-		- the specified expression on the right side
-	If isExclusive is true, the function finds for an exact match to the specfied expression.
-	If false, it finds for a matching substring instead.
-*/
 unordered_set<int> PKB::findPattern(string expr, bool isExclusive)
 {
 	unordered_set<int> validStm;
@@ -588,12 +417,6 @@ unordered_set<int> PKB::findPattern(string expr, bool isExclusive)
 	return validStm;
 }
 
-/*
-	Search for pairs of an assign statement and left-hand side variable with
-		the right side expression matching the specified expression
-	If isExclusive is true, the function finds for an exact match to the specfied expression.
-	If false, it finds for a matching substring instead.
-*/
 unordered_set<pair<int, string>, intStringhash> PKB::findPatternPairs(string expr, bool isExclusive)
 {
 	unordered_set<pair<int, string>, intStringhash> validPairs;

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -20,11 +20,13 @@ PKB::PKB()
 {
 }
 
+// add a procedure to procList
 void PKB::addProc(string name)
 {
 	procList.emplace(name);
 }
 
+//add statement to its respective StmList and set stmTypeList[stmNo] to type 
 void PKB::addStatement(int stmNo, stmType type)
 {
 	stmTypeList.assign(stmNo, type);
@@ -51,16 +53,25 @@ void PKB::addStatement(int stmNo, stmType type)
 	}
 }
 
+// add variable to varList
 void PKB::addVariable(string name)
 {
 	varList.emplace(name);
 }
 
+// add constant to constList
 void PKB::addConstant(string value)
 {
 	constList.emplace(value);
 }
 
+/*
+	add the follows relation in FollowStorage
+	Returns false if	1) the pair is already stored
+						2) the followed statement has another follower stored
+						3) the follower is following another statement
+						4) stm2 <= stm1 or stm1, stm2 <= 0
+*/
 bool PKB::addFollow(int stm1, int stm2)
 {
 	if (stm2 <= stm1 || stm1 <= 0 || stm2 <= 0)
@@ -70,16 +81,33 @@ bool PKB::addFollow(int stm1, int stm2)
 	return fStore.addFollow(stm1, stm2);
 }
 
-bool PKB::setFollowers(int stm, unordered_set<int> stmList)
+/*
+	Sets the list of followers of 'stm' to be 'stmList' in FollowStorage
+	Every FollowStar pair is stored as well
+	If stm already has a list of followers, it is not replaced and it return false
+*/
+bool PKB::setAllFollowing(int stm, unordered_set<int> stmList)
 {
 	return fStore.setAllFollowing(stm, stmList);
 }
 
-bool PKB::setStmFollowedBy(int stm, unordered_set<int> stmList)
+/*
+	Sets the list of followed of 'stm' to be 'stmList' in FollowStorage
+	Every FollowStar pair is stored as well
+	If stm already has a list of followed, it is not replaced and it return false
+*/
+bool PKB::setAllFollowedBy(int stm, unordered_set<int> stmList)
 {
 	return fStore.setAllFollowedBy(stm, stmList);
 }
 
+
+/*
+	Adds the parent relation into the various lists in the storage
+	Returns false if	1) the pair is already stored
+						2) the child already has another parent
+						3) stm2 <= stm1 or stm1, stm2 <= 0
+*/
 bool PKB::addParent(int stm1, int stm2)
 {
 	if (stm2 <= stm1 || stm1 <= 0 || stm2 <= 0)
@@ -89,25 +117,45 @@ bool PKB::addParent(int stm1, int stm2)
 	return pStore.addParent_Child(stm1, stm2);
 }
 
+/*
+	Sets the list of ancestors of 'stm' in ParentStorage
+	Each Parent* pair is stored as well
+	If stm already has a list of ancestors, it is not replaced and it return false
+*/
 bool PKB::setAncestors(int stm, unordered_set<int> stmList)
 {
 	return pStore.setAncestors(stm, stmList);
 }
 
+/*
+	Sets the list of descendants of 'stm' in ParentStorage
+	Each Parent* pair is stored as well
+	If stm already has a list of descendants, it is not replaced and it return false
+*/
 bool PKB::setDescendants(int stm, unordered_set<int> stmList)
 {
 	return pStore.setDescendants(stm, stmList);
 }
 
+/*
+	add the Uses relation for a Statement in UseStorage
+	Returns false if	1) the pair is already stored
+						2) stm <= 0 and variable is an empty string
+*/
 bool PKB::addUsesStm(int stm, string variable)
 {
-	if (variable == "")
+	if (stm <= 0 || variable == "")
 	{
 		return false;
 	}
 	return uStore.addUsesStm(stm, variable);
 }
 
+/*
+	add the Uses relation for a Procedure in UseStorage
+	Returns false if	1) the pair is already stored
+						2) procedure or variable is an empty string
+*/
 bool PKB::addUsesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
@@ -117,6 +165,11 @@ bool PKB::addUsesProc(string procedure, string variable)
 	return uStore.addUsesProc(procedure, variable);
 }
 
+/*
+	add the Modifies relation for a Statement in UseStorage
+	Returns false if	1) the pair is already stored
+						2) stm <= 0 and variable is an empty string
+*/
 bool PKB::addModifiesStm(int stm, string variable)
 {
 	if (variable == "")
@@ -126,6 +179,11 @@ bool PKB::addModifiesStm(int stm, string variable)
 	return mStore.addModifiesStm(stm, variable);
 }
 
+/*
+	add the Modifies relation for a Procedure in UseStorage
+	Returns false if	1) the pair is already stored
+						2) procedure or variable is an empty string
+*/
 bool PKB::addModifiesProc(string procedure, string variable)
 {
 	if (procedure == "" || variable == "")
@@ -135,246 +193,346 @@ bool PKB::addModifiesProc(string procedure, string variable)
 	return mStore.addModifiesProc(procedure, variable);
 }
 
-bool PKB::addAssign(int stm, string variable, string expr)
+/* 
+	add a pattern for an assign statement to patternList
+	returns false if 'stm' already exist in the list with another pattern
+*/
+bool PKB::addAssignPattern(int stm, string variable, string expr)
 {
 	return patternList.emplace(stm, pair<string, string>(variable, expr)).second;
 }
 
+// returns the stored list of procedures
 unordered_set<string> PKB::getProcList()
 {
 	return procList;
 }
 
+// returns the total number of statements in the entire program
 int PKB::getTotalStmNo()
 {
 	return stmTypeList.size();
 }
 
+// return the statement type of stm
 stmType PKB::getStmType(int stm)
 {
 	return stmTypeList.at(stm);
 }
 
+// returns the stored list of read statements
 unordered_set<int> PKB::getReadStms()
 {
 	return readStmList;
 }
 
+// returns the stored list of print statements
 unordered_set<int> PKB::getPrintStms()
 {
 	return printStmList;
 }
 
+// returns the stored list of assign statements
 unordered_set<int> PKB::getAssignStms()
 {
 	return assignStmList;
 }
 
+// returns the stored list of if statements
 unordered_set<int> PKB::getIfStms()
 {
 	return ifStmList;
 }
 
+// returns the stored list of while statements
 unordered_set<int> PKB::getWhileStms()
 {
 	return whileStmList;
 }
 
+// returns the stored list of variables
 unordered_set<string> PKB::getVariables()
 {
 	return varList;
 }
 
+// returns the stored list of constants
 unordered_set<string> PKB::getConstants()
 {
 	return constList;
 }
 
+// checks if there is at least one follows relation
 bool PKB::hasFollowRelation()
 {
 	return !fStore.isEmpty();
 }
 
+// checks if the relation Follows*(stm1, stm2) exist
 bool PKB::hasFollowStarPair(int stm1, int stm2)
 {
 	return fStore.hasFollowStarPair(pair<int, int>(stm1, stm2));
 }
 
+/*
+	return the statement followed by 'stm'
+	return 0 if 'stm' is not found
+*/
 int PKB::getStmFollowedBy(int stm)
 {
 	return fStore.getStmFollowedBy(stm);
 }
 
+/*
+	return the statement following 'stm'
+	return 0 if 'stm' is not found
+*/
 int PKB::getFollower(int stm)
 {
 	return fStore.getFollower(stm);
 }
 
+/*
+	return a list of statements that is directly/indirectly following 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> PKB::getAllFollowing(int stm)
 {
 	return fStore.getAllFollowing(stm);
 }
 
+/*
+	return a list of statements that is directly/indirectly followed by 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> PKB::getAllFollowedBy(int stm)
 {
 	return fStore.getAllFollowedBy(stm);
 }
 
+// returns a list of all statements that follows another
 unordered_set<int> PKB::getAllFollowers()
 {
 	return fStore.getAllFollowers();
 }
 
+// returns a list of all statements that is followed by another
 unordered_set<int> PKB::getAllFollowed()
 {
 	return fStore.getAllFollowed();
 }
 
+// returns a list of all follows pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getFollowPairs()
 {
 	return fStore.getFollowPairs();
 }
 
+// returns a list of all follows* pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getFollowStarPairs()
 {
 	return fStore.getFollowStarPairs();
 }
 
+// checks if there is at least one Parent relationship
 bool PKB::hasParentRelation()
 {
 	return !pStore.isEmpty();
 }
 
+// checks if stm is a parent of another
 bool PKB::isParent(int stm)
 {
 	return pStore.isParent(stm);
 }
 
+// checks if stm is a child of another
 bool PKB::isChild(int stm)
 {
 	return pStore.isChild(stm);
 }
 
+// checks if the relation Parent*(stm1, stm2) exist
 bool PKB::hasAncDescPair(int stm1, int stm2)
 {
 	return pStore.hasAncDescPair(pair<int, int>(stm1, stm2));
 }
 
+/*
+	return the statement that is the parent of 'stm'
+	return 0 if 'stm' is not found
+*/
 int PKB::getParent(int stm)
 {
 	return pStore.getParent(stm);
 }
 
+/*
+	return the list of statements that is the children of 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> PKB::getChildren(int stm)
 {
 	return pStore.getChildren(stm);
 }
 
+/*
+	return the list of statements that is the ancestors of 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> PKB::getAncestors(int stm)
 {
 	return pStore.getAncestors(stm);
 }
 
+/*
+	return the list of statements that is the descendants of 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<int> PKB::getDescendants(int stm)
 {
 	return pStore.getDescendants(stm);
 }
 
+// returns a list of all statements that is the parent of another
 unordered_set<int> PKB::getAllParents()
 {
 	return pStore.getAllParent();
 }
 
+// returns a list of all statements that is the child of another
 unordered_set<int> PKB::getAllChildren()
 {
 	return pStore.getAllChildren();
 }
 
+// returns a list of all parent pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getParentChildPairs()
 {
 	return pStore.getParentChildPairs();
 }
 
+// returns a list of all parent* pairs
 unordered_set<pair<int, int>, intPairhash> PKB::getAncDescPairs()
 {
 	return pStore.getAncDescPair();
 }
 
-bool PKB::isUsing(int stm, string variable)
+// checks if the relation Uses(stm, variable) exist
+bool PKB::isStmUsing(int stm, string variable)
 {
 	return uStore.containsStmVarPair(pair<int, string>(stm, variable) );
 }
 
-bool PKB::isUsing(string procedure, string variable)
+// checks if the relation Uses(procedure, variable) exist
+bool PKB::isProcUsing(string procedure, string variable)
 {
 	return uStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
+/*
+	return the list of variables that is used by 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<string> PKB::getVarUsedByStm(int stm)
 {
 	return uStore.getVarUsedByStm(stm);
 }
 
+/*
+	return the list of variables that is used by 'procedure'
+	return an empty set if 'procedure' is not found
+*/
 unordered_set<string> PKB::getVarUsedByProc(string procedure)
 {
 	return uStore.getVarUsedByProc(procedure);
 }
 
+/*
+	return the list of statements that is using 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<int> PKB::getStmUsing(string variable)
 {
 	return uStore.getStmUsing(variable);
 }
 
+/*
+	return the list of procedure that is using 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<string> PKB::getProcUsing(string variable)
 {
 	return uStore.getProcUsing(variable);
 }
 
+// returns a list of all Uses pairs for statements
 unordered_set<pair<int, string>, intStringhash> PKB::getStmVarUsePairs()
 {
 	return uStore.getStmVarPairs();
 }
 
+// returns a list of all Uses pairs for procedures
 unordered_set<pair<string, string>, strPairhash> PKB::getProcVarUsePairs()
 {
 	return uStore.getProcVarPairs();
 }
 
-bool PKB::isModifying(int stm, string variable)
+// checks if the relation Modifies(stm, variable) exist
+bool PKB::isStmModifying(int stm, string variable)
 {
 	return mStore.containsStmVarPair(pair<int, string>(stm, variable));
 }
 
-bool PKB::isModifying(string procedure, string variable)
+// checks if the relation Modifies(procedure, variable) exist
+bool PKB::isProcModifying(string procedure, string variable)
 {
 	return mStore.containsProcVarPair(pair<string, string>(procedure, variable));
 }
 
+/*
+	return the list of variables that is modified by 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<string> PKB::getVarModifiedByStm(int stm)
 {
 	return mStore.getVarModifiedByStm(stm);
 }
 
+/*
+	return the list of variables that is modified by 'procedure'
+	return an empty set if 'procedure' is not found
+*/
 unordered_set<string> PKB::getVarModifiedByProc(string procedure)
 {
 	return mStore.getVarModifiedByProc(procedure);
 }
 
+/*
+	return the list of statements that is modifying 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<int> PKB::getStmModifying(string variable)
 {
 	return mStore.getStmModifying(variable);
 }
 
+/*
+	return the list of procedures that is modifying 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<string> PKB::getProcModifying(string variable)
 {
 	return mStore.getProcModifying(variable);
 }
 
+// returns a list of all Modifies pairs for statements
 unordered_set<pair<int, string>, intStringhash> PKB::getStmVarModifyPairs()
 {
 	return mStore.getStmVarPairs();
 }
 
+// returns a list of all Modifies pairs for procedures
 unordered_set<pair<string, string>, strPairhash> PKB::getProcVarModifyPairs()
 {
 	return mStore.getProcVarPairs();

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -1,6 +1,6 @@
 #include "PKB.h"
 
-string PKB::procName;
+unordered_set<string> PKB::procList;
 vector<stmType> PKB::stmTypeList;
 unordered_set<string> PKB::varList;
 unordered_set<string> PKB::constList;
@@ -22,7 +22,7 @@ PKB::PKB()
 
 void PKB::addProc(string name)
 {
-	procName = name;
+	procList.emplace(name);
 }
 
 void PKB::addStatement(int stmNo, stmType type)
@@ -140,9 +140,9 @@ bool PKB::addAssign(int stm, string variable, string expr)
 	return patternList.emplace(stm, pair<string, string>(variable, expr)).second;
 }
 
-string PKB::getProcName()
+unordered_set<string> PKB::getProcList()
 {
-	return procName;
+	return procList;
 }
 
 int PKB::getTotalStmNo()

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -10,6 +10,7 @@ using namespace std;
 #include "ParentStorage.h"
 #include "UseStorage.h"
 #include "ModifyStorage.h"
+#include "Hasher.h"
 
 enum stmType { read, print, assign, whileStm, ifStm };
 
@@ -108,9 +109,9 @@ public:
 	unordered_set< pair<string, string>, strPairhash> getProcVarModifyPairs();
 
 	//For Pattern clauses
-	vector<int> findPattern(string variable, string expr, bool isExclusive);
-	vector<int> findPattern(string expr, bool isExclusive);
-	vector<pair<int, string>> findPatternPairs(string expr, bool isExclusive);
+	unordered_set<int> findPattern(string variable, string expr, bool isExclusive);
+	unordered_set<int> findPattern(string expr, bool isExclusive);
+	unordered_set<pair<int, string>, intStringhash> findPatternPairs(string expr, bool isExclusive);
 
 private:
 	static string procName;

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -51,7 +51,7 @@ public:
 	bool addAssign(int stm, string variable, string expr);
 
 	//general getter methods
-	string getProcName();
+	unordered_set<string> getProcList();
 	int getTotalStmNo();
 	stmType getStmType(int stm);
 	unordered_set<int> getReadStms();
@@ -114,7 +114,7 @@ public:
 	unordered_set<pair<int, string>, intStringhash> findPatternPairs(string expr, bool isExclusive);
 
 private:
-	static string procName;
+	static unordered_set<string> procList;
 	static vector<stmType> stmTypeList;
 	static unordered_set<string> varList;
 	static unordered_set<string> constList;

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -101,8 +101,8 @@ public:
 	//For Modifies relations
 	bool isModifying(int stm, string variable);
 	bool isModifying(string procedure, string variable);
-	unordered_set<string> getModifiedVar(int stm);
-	unordered_set<string> getModifiedVar(string procedure);
+	unordered_set<string> getVarModifiedByStm(int stm);
+	unordered_set<string> getVarModifiedByProc(string procedure);
 	unordered_set<int> getStmModifying(string variable);
 	unordered_set<string> getProcModifying(string variable);
 	unordered_set< pair<int, string>, intStringhash> getStmVarModifyPairs();

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -231,25 +231,25 @@ public:
 	bool hasAncDescPair(int stm1, int stm2);
 
 	/*
-		return the statement that is the parent of 'stm'
+		return a statement that is the parent of 'stm'
 		return 0 if 'stm' is not found
 	*/
 	int getParent(int stm);
 
 	/*
-		return the list of statements that is the children of 'stm'
+		return a list of statements that is the children of 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<int> getChildren(int stm);
 
 	/*
-		return the list of statements that is the ancestors of 'stm'
+		return a list of statements that is the ancestors of 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<int> getAncestors(int stm);
 
 	/*
-		return the list of statements that is the descendants of 'stm'
+		return a list of statements that is the descendants of 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<int> getDescendants(int stm);
@@ -276,25 +276,27 @@ public:
 	bool isProcUsing(string procedure, string variable);
 
 	/*
-		return the list of variables that is used by 'stm'
+		return a list of variables that is used by 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<string> getVarUsedByStm(int stm);
 
 	/*
-		return the list of variables that is used by 'procedure'
+		return a list of variables that is used by 'procedure'
 		return an empty set if 'procedure' is not found
 	*/
 	unordered_set<string> getVarUsedByProc(string procedure);
 
 	/*
-		return the list of statements that is using 'variable'
+		return a list of statements that is using 'variable'
+		returns a list of all statements that used a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<int> getStmUsing(string variable);
 
 	/*
-		return the list of procedure that is using 'variable'
+		return a list of procedure that is using 'variable'
+		returns a list of all procedures that used a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<string> getProcUsing(string variable);
@@ -315,25 +317,27 @@ public:
 	bool isProcModifying(string procedure, string variable);
 
 	/*
-		return the list of variables that is modified by 'stm'
+		return a list of variables that is modified by 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<string> getVarModifiedByStm(int stm);
 
 	/*
-		return the list of variables that is modified by 'procedure'
+		return a list of variables that is modified by 'procedure'
 		return an empty set if 'procedure' is not found
 	*/
 	unordered_set<string> getVarModifiedByProc(string procedure);
 
 	/*
-		return the list of statements that is modifying 'variable'
+		return a list of statements that modifies 'variable'
+		returns a list of all statements that modifies a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<int> getStmModifying(string variable);
 
 	/*
-		return the list of procedures that is modifying 'variable'
+		return a list of procedures that modifies 'variable'
+		returns a list of all procedures that modifies a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<string> getProcModifying(string variable);

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -14,10 +14,9 @@ using namespace std;
 enum stmType { read, print, assign, whileStm, ifStm };
 
 /*
-	Accepts data from the Front-End's Parser, sends data to the PostProcessor when called and
-	accepts new data from it as well. PKB will also reply to queries made by the PQL's Query Evaluator.
-	Stores relationships data in their respective Storage classes while other information
-	like procedure name, statement types, statement lists and pattern are stored locally
+	Accepts relationship, pattern and other general data from Parser and DesignExtractor and
+	stores them here or into their respective Storage classes.
+	Reply to queries made by the QueryEvaluator.
 */
 class PKB {
 public:
@@ -40,12 +39,12 @@ public:
 	bool setDescendants(int stm, unordered_set<int> stmList);
 
 	//adding Uses relationships
-	bool addUses(int stm, string variable);
-	bool addUses(string procedure, string variable);
+	bool addUsesStm(int stm, string variable);
+	bool addUsesProc(string procedure, string variable);
 
 	//adding Modifies relationships
-	bool addModifies(int stm, string variable);
-	bool addModifies(string procedure, string variable);
+	bool addModifiesStm(int stm, string variable);
+	bool addModifiesProc(string procedure, string variable);
 
 	//adding patterns
 	bool addAssign(int stm, string variable, string expr);
@@ -64,16 +63,15 @@ public:
 
 	//For Follows/Follows* relations
 	bool hasFollowRelation();
-	bool hasFollow_S_Pair(int stm1, int stm2);
-	int getPrvStm(int stm);
-	int getNxtStm(int stm);
+	bool hasFollowStarPair(int stm1, int stm2);
+	int getStmFollowedBy(int stm);
+	int getFollower(int stm);
 	unordered_set<int> getAllFollowing(int stm);
 	unordered_set<int> getAllFollowedBy(int stm);
 	unordered_set<int> getAllFollowers();
 	unordered_set<int> getAllFollowed();
 	unordered_set< pair<int, int>, intPairhash> getFollowPairs();
-	unordered_set< pair<int, int>, intPairhash> getFollow_S_Pairs();
-	unordered_set<int> getFollowRoots();
+	unordered_set< pair<int, int>, intPairhash> getFollowStarPairs();
 
 	//For Parent/Parent* relations
 	bool hasParentRelation();
@@ -82,19 +80,18 @@ public:
 	bool hasAncDescPair(int stm1, int stm2);
 	int getParent(int stm);
 	unordered_set<int> getChildren(int stm);
-	unordered_set<int> getAllAncestors(int stm);
-	unordered_set<int> getAllDescendants(int stm);
+	unordered_set<int> getAncestors(int stm);
+	unordered_set<int> getDescendants(int stm);
 	unordered_set<int> getAllParents();
 	unordered_set<int> getAllChildren();
 	unordered_set< pair<int, int>, intPairhash> getParentChildPairs();
 	unordered_set< pair<int, int>, intPairhash> getAncDescPairs();
-	unordered_set<int> getParentRoots();
 
 	//For Uses relations
 	bool isUsing(int stm, string variable);
 	bool isUsing(string procedure, string variable);
-	unordered_set<string> getUsedVar(int stm);
-	unordered_set<string> getUsedVar(string procedure);
+	unordered_set<string> getVarUsedByStm(int stm);
+	unordered_set<string> getVarUsedByProc(string procedure);
 	unordered_set<int> getStmUsing(string variable);
 	unordered_set<string> getProcUsing(string variable);
 	unordered_set< pair<int, string>, intStringhash> getStmVarUsePairs();

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -12,7 +12,7 @@ using namespace std;
 #include "ModifyStorage.h"
 #include "Hasher.h"
 
-enum stmType { read, print, assign, whileStm, ifStm };
+enum stmType { read, print, assign, whileStm, ifStm, call};
 
 /*
 	Accepts relationship, pattern and other general data from Parser and DesignExtractor and
@@ -31,8 +31,8 @@ public:
 
 	//adding Follows relationships
 	bool addFollow(int stm1, int stm2);
-	bool setFollowers(int stm, unordered_set<int> stmList);
-	bool setStmFollowedBy(int stm, unordered_set<int> stmList);
+	bool setAllFollowing(int stm, unordered_set<int> stmList);
+	bool setAllFollowedBy(int stm, unordered_set<int> stmList);
 
 	//adding Parent relationships
 	bool addParent(int stm1, int stm2);
@@ -48,7 +48,7 @@ public:
 	bool addModifiesProc(string procedure, string variable);
 
 	//adding patterns
-	bool addAssign(int stm, string variable, string expr);
+	bool addAssignPattern(int stm, string variable, string expr);
 
 	//general getter methods
 	unordered_set<string> getProcList();
@@ -89,8 +89,8 @@ public:
 	unordered_set< pair<int, int>, intPairhash> getAncDescPairs();
 
 	//For Uses relations
-	bool isUsing(int stm, string variable);
-	bool isUsing(string procedure, string variable);
+	bool isStmUsing(int stm, string variable);
+	bool isProcUsing(string procedure, string variable);
 	unordered_set<string> getVarUsedByStm(int stm);
 	unordered_set<string> getVarUsedByProc(string procedure);
 	unordered_set<int> getStmUsing(string variable);
@@ -99,8 +99,8 @@ public:
 	unordered_set< pair<string, string>, strPairhash> getProcVarUsePairs();
 
 	//For Modifies relations
-	bool isModifying(int stm, string variable);
-	bool isModifying(string procedure, string variable);
+	bool isStmModifying(int stm, string variable);
+	bool isProcModifying(string procedure, string variable);
 	unordered_set<string> getVarModifiedByStm(int stm);
 	unordered_set<string> getVarModifiedByProc(string procedure);
 	unordered_set<int> getStmModifying(string variable);

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -23,94 +23,353 @@ class PKB {
 public:
 	PKB();
 
-	//general adder methods
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//General adder Methods			/////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// add a procedure to procList
 	void addProc(string procName);
+
+	//add statement to its respective StmList and set stmTypeList[stmNo] to type 
 	void addStatement(int stmNo, stmType type);
+
+	// add variable to varList
 	void addVariable(string name);
+
+	// add constant to constList
 	void addConstant(string value);
 
-	//adding Follows relationships
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Follows adder & setter Methods	/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		add the follows relation in FollowStorage
+		Returns false if
+			1) the pair is already stored
+			2) the followed statement has another follower stored
+			3) the follower is following another statement
+			4) stm2 <= stm1 or stm1, stm2 <= 0
+	*/
 	bool addFollow(int stm1, int stm2);
+
+	/*
+		Sets the list of followers of 'stm' to be 'stmList' in FollowStorage
+		Every FollowStar pair is stored as well
+		If stm already has a list of followers, it is not replaced and it return false
+	*/
 	bool setAllFollowing(int stm, unordered_set<int> stmList);
+
+	/*
+		Sets the list of followed of 'stm' to be 'stmList' in FollowStorage
+		Every FollowStar pair is stored as well
+		If stm already has a list of followed, it is not replaced and it return false
+	*/
 	bool setAllFollowedBy(int stm, unordered_set<int> stmList);
 
-	//adding Parent relationships
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Parent adder & setter Methods		/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		Adds the parent relation into the various lists in the storage
+		Returns false if	
+			1) the pair is already stored
+			2) the child already has another parent
+			3) stm2 <= stm1 or stm1, stm2 <= 0
+	*/
 	bool addParent(int stm1, int stm2);
+
+	/*
+		Sets the list of ancestors of 'stm' in ParentStorage
+		Each Parent* pair is stored as well
+		If stm already has a list of ancestors, it is not replaced and it return false
+	*/
 	bool setAncestors(int stm, unordered_set<int> stmList);
+
+	/*
+		Sets the list of descendants of 'stm' in ParentStorage
+		Each Parent* pair is stored as well
+		If stm already has a list of descendants, it is not replaced and it return false
+	*/
 	bool setDescendants(int stm, unordered_set<int> stmList);
 
-	//adding Uses relationships
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Uses adder Methods			/////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		add the Uses relation for a Statement in UseStorage
+		Returns false if
+			1) the pair is already stored
+			2) stm <= 0 and variable is an empty string
+	*/
 	bool addUsesStm(int stm, string variable);
-	bool addUsesProc(string procedure, string variable);
 
-	//adding Modifies relationships
+	/*
+		add the Uses relation for a Procedure in UseStorage
+		Returns false if
+			1) the pair is already stored
+			2) procedure or variable is an empty string
+	*/
+	bool addUsesProc(string procedure, string variable);
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Modifies adder Methods			/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		add the Modifies relation for a Statement in UseStorage
+		Returns false if
+			1) the pair is already stored
+			2) stm <= 0 and variable is an empty string
+	*/
 	bool addModifiesStm(int stm, string variable);
+
+	/*
+		add the Modifies relation for a Procedure in UseStorage
+		Returns false if
+			1) the pair is already stored
+			2) procedure or variable is an empty string
+	*/
 	bool addModifiesProc(string procedure, string variable);
 
-	//adding patterns
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Pattern adder Methods			/////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		add a pattern for an assign statement to patternList
+		returns false if 'stm' already exist in the list with another pattern
+	*/
 	bool addAssignPattern(int stm, string variable, string expr);
 
-	//general getter methods
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//General Getter Methods	/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// returns the stored list of procedures
 	unordered_set<string> getProcList();
+
+	// returns the total number of statements in the entire program
 	int getTotalStmNo();
+
+	// return the statement type of stm
 	stmType getStmType(int stm);
+
+	// returns the stored list of read statements
 	unordered_set<int> getReadStms();
+
+	// returns the stored list of print statements
 	unordered_set<int> getPrintStms();
+
+	// returns the stored list of assign statements
 	unordered_set<int> getAssignStms();
+
+	// returns the stored list of if statements
 	unordered_set<int> getIfStms();
+
+	// returns the stored list of while statements
 	unordered_set<int> getWhileStms();
+
+	// returns the stored list of variables
 	unordered_set<string> getVariables();
+
+	// returns the stored list of constants
 	unordered_set<string> getConstants();
 
-	//For Follows/Follows* relations
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Follows Getter Methods	/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// checks if there is at least one follows relation
 	bool hasFollowRelation();
+
+	// checks if the relation Follows*(stm1, stm2) exist
 	bool hasFollowStarPair(int stm1, int stm2);
+
+	/*
+		return the statement followed by 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getStmFollowedBy(int stm);
+
+	/*
+		return the statement following 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getFollower(int stm);
+
+	/*
+		return a list of statements that is directly/indirectly following 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAllFollowing(int stm);
+
+	/*
+		return a list of statements that is directly/indirectly followed by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAllFollowedBy(int stm);
+
+	// returns a list of all statements that follows another
 	unordered_set<int> getAllFollowers();
+
+	// returns a list of all statements that is followed by another
 	unordered_set<int> getAllFollowed();
+
+	// returns a list of all follows pairs
 	unordered_set< pair<int, int>, intPairhash> getFollowPairs();
+
+	// returns a list of all follows* pairs
 	unordered_set< pair<int, int>, intPairhash> getFollowStarPairs();
 
-	//For Parent/Parent* relations
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Parent Getter Methods		/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// checks if there is at least one Parent relationship
 	bool hasParentRelation();
+
+	// checks if stm is a parent of another
 	bool isParent(int stm);
+
+	// checks if stm is a child of another
 	bool isChild(int stm);
+
+	// checks if the relation Parent*(stm1, stm2) exist
 	bool hasAncDescPair(int stm1, int stm2);
+
+	/*
+		return the statement that is the parent of 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getParent(int stm);
+
+	/*
+		return the list of statements that is the children of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getChildren(int stm);
+
+	/*
+		return the list of statements that is the ancestors of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAncestors(int stm);
+
+	/*
+		return the list of statements that is the descendants of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getDescendants(int stm);
+
+	// returns a list of all statements that is the parent of another
 	unordered_set<int> getAllParents();
+
+	// returns a list of all statements that is the child of another
 	unordered_set<int> getAllChildren();
+
+	// returns a list of all parent pairs
 	unordered_set< pair<int, int>, intPairhash> getParentChildPairs();
+
+	// returns a list of all parent* pairs
 	unordered_set< pair<int, int>, intPairhash> getAncDescPairs();
 
-	//For Uses relations
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Uses Getter Methods		/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// checks if the relation Uses(stm, variable) exist
 	bool isStmUsing(int stm, string variable);
+
+	// checks if the relation Uses(procedure, variable) exist
 	bool isProcUsing(string procedure, string variable);
+
+	/*
+		return the list of variables that is used by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<string> getVarUsedByStm(int stm);
+
+	/*
+		return the list of variables that is used by 'procedure'
+		return an empty set if 'procedure' is not found
+	*/
 	unordered_set<string> getVarUsedByProc(string procedure);
+
+	/*
+		return the list of statements that is using 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<int> getStmUsing(string variable);
+
+	/*
+		return the list of procedure that is using 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<string> getProcUsing(string variable);
+
+	// returns a list of all Uses pairs for statements
 	unordered_set< pair<int, string>, intStringhash> getStmVarUsePairs();
+
+	// returns a list of all Uses pairs for procedures
 	unordered_set< pair<string, string>, strPairhash> getProcVarUsePairs();
 
-	//For Modifies relations
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Modifies Getter Methods	/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// checks if the relation Modifies(stm, variable) exist
 	bool isStmModifying(int stm, string variable);
+
+	// checks if the relation Modifies(procedure, variable) exist
 	bool isProcModifying(string procedure, string variable);
+
+	/*
+		return the list of variables that is modified by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<string> getVarModifiedByStm(int stm);
+
+	/*
+		return the list of variables that is modified by 'procedure'
+		return an empty set if 'procedure' is not found
+	*/
 	unordered_set<string> getVarModifiedByProc(string procedure);
+
+	/*
+		return the list of statements that is modifying 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<int> getStmModifying(string variable);
+
+	/*
+		return the list of procedures that is modifying 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<string> getProcModifying(string variable);
+
+	// returns a list of all Modifies pairs for statements
 	unordered_set< pair<int, string>, intStringhash> getStmVarModifyPairs();
+
+	// returns a list of all Modifies pairs for procedures
 	unordered_set< pair<string, string>, strPairhash> getProcVarModifyPairs();
 
-	//For Pattern clauses
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//Pattern Getter Methods	/////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+		Search for assign statements with pattern matching
+			- the specified variable ont the left side and
+			- the specified expression on the right side
+		If isExclusive is true, the function finds for an exact match to the specfied expression.
+		If false, it finds for a matching substring instead.
+	*/
 	unordered_set<int> findPattern(string variable, string expr, bool isExclusive);
+
+	/*
+		Search for assign statements with pattern matching
+			- the specified expression on the right side
+		If isExclusive is true, the function finds for an exact match to the specfied expression.
+		If false, it finds for a matching substring instead.
+	*/
 	unordered_set<int> findPattern(string expr, bool isExclusive);
+
+	/*
+		Search for pairs of an assign statement and left-hand side variable with
+			the right side expression matching the specified expression
+		If isExclusive is true, the function finds for an exact match to the specfied expression.
+		If false, it finds for a matching substring instead.
+	*/
 	unordered_set<pair<int, string>, intStringhash> findPatternPairs(string expr, bool isExclusive);
 
 private:

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -35,7 +35,7 @@ bool ParentStorage::addParent_Child(int parent, int child)
 		itrpr.first->second.parent = parent;
 	}
 
-	// if a new parent statement is added into the table, add to the root list
+	// if parent exist in parentTable
 	if (!parentTable.emplace(parent, pRelationships{ 0, {child}, {}, {} }).second)
 	{
 		parentTable.find(parent)->second.children.emplace(child);
@@ -47,9 +47,9 @@ bool ParentStorage::addParent_Child(int parent, int child)
 }
 
 /*
-	Sets "ancestors" of the descendant
+	Sets "ancestors" of 'descendant'
 	Each ancestor - descendant pair is entered into anc_DescPairList
-	If descendant already has a list of ancestors, it is not replaced and it return false
+	If 'descendant' already has a list of ancestors, it is not replaced and it return false
 */
 bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 {
@@ -67,9 +67,9 @@ bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 }
 
 /*
-	Sets "descendants" of the ancestor
+	Sets "descendants" of 'ancestor'
 	Each ancestor - descendant pair is entered into anc_DescPairList
-	If ancestor already has a list of descendants, it is not replaced and it return false
+	If 'ancestor' already has a list of descendants, it is not replaced and it return false
 */
 bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 {
@@ -86,6 +86,7 @@ bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 	return true;
 }
 
+// return true if parentTable is empty
 bool ParentStorage::isEmpty()
 {
 	return parentTable.size() == 0;
@@ -103,14 +104,14 @@ bool ParentStorage::isChild(int stm)
 	return childrenList.find(stm) != childrenList.end();
 }
 
-// returns true if parent* pair is found
+// returns true if the specified parent* pair is found
 bool ParentStorage::hasAncDescPair(pair<int, int> pair)
 {
 	return anc_DescPairList.find(pair) != anc_DescPairList.end();
 }
 
 /*
-	return the statement that is the parent of the statement specified
+	return the statement that is the parent of 'stm'
 	return 0 if 'stm' is not found
 */
 int ParentStorage::getParent(int stm)
@@ -123,7 +124,7 @@ int ParentStorage::getParent(int stm)
 }
 
 /*
-	return the list of statements that is the children of the statement specified
+	return the list of statements that is the children of 'stm'
 	return an empty set if 'stm' is not found
 */
 unordered_set<int> ParentStorage::getChildren(int stm)
@@ -136,7 +137,7 @@ unordered_set<int> ParentStorage::getChildren(int stm)
 }
 
 /*
-	return the list of statements that is the ancestor of the statement specified
+	return the list of statements that is the ancestor of 'stm'
 	return an empty set if 'stm' is not found
 */
 unordered_set<int> ParentStorage::getAncestors(int stm)
@@ -149,7 +150,7 @@ unordered_set<int> ParentStorage::getAncestors(int stm)
 }
 
 /*
-	return the list of statements that is the descendants of the statement specified
+	return the list of statements that is the descendants of 'stm'
 	return an empty set if 'stm' is not found
 */
 unordered_set<int> ParentStorage::getDescendants(int stm)
@@ -161,21 +162,25 @@ unordered_set<int> ParentStorage::getDescendants(int stm)
 	return {};
 }
 
+// returns a list of all statements that is the parent of another
 unordered_set<int> ParentStorage::getAllParent()
 {
 	return parentList;
 }
 
+// returns a list of all statements that is the child of another
 unordered_set<int> ParentStorage::getAllChildren()
 {
 	return childrenList;
 }
 
+// returns a list of all parent pairs
 unordered_set<pair<int, int>, intPairhash> ParentStorage::getParentChildPairs()
 {
 	return parent_ChildPairList;
 }
 
+// returns a list of all parent* pairs
 unordered_set<pair<int, int>, intPairhash> ParentStorage::getAncDescPair()
 {
 	return anc_DescPairList;

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -91,17 +91,20 @@ bool ParentStorage::isEmpty()
 	return parentTable.size() == 0;
 }
 
+// returns true if the specified statement is a parent of another
 bool ParentStorage::isParent(int stm)
 {
 	return parentList.find(stm) != parentList.end();
 }
 
+// returns true if the specified statement is a child of another
 bool ParentStorage::isChild(int stm)
 {
 	return childrenList.find(stm) != childrenList.end();
 }
 
-bool ParentStorage::containsAnc_Desc(pair<int, int> pair)
+// returns true if parent* pair is found
+bool ParentStorage::hasAncDescPair(pair<int, int> pair)
 {
 	return anc_DescPairList.find(pair) != anc_DescPairList.end();
 }
@@ -110,7 +113,7 @@ bool ParentStorage::containsAnc_Desc(pair<int, int> pair)
 	return the statement that is the parent of the statement specified
 	return 0 if 'stm' is not found
 */
-int ParentStorage::getParentOf(int stm)
+int ParentStorage::getParent(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
 	{
@@ -123,7 +126,7 @@ int ParentStorage::getParentOf(int stm)
 	return the list of statements that is the children of the statement specified
 	return an empty set if 'stm' is not found
 */
-unordered_set<int> ParentStorage::getChildrenOf(int stm)
+unordered_set<int> ParentStorage::getChildren(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
 	{
@@ -136,7 +139,7 @@ unordered_set<int> ParentStorage::getChildrenOf(int stm)
 	return the list of statements that is the ancestor of the statement specified
 	return an empty set if 'stm' is not found
 */
-unordered_set<int> ParentStorage::getAncestorsOf(int stm)
+unordered_set<int> ParentStorage::getAncestors(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
 	{
@@ -149,7 +152,7 @@ unordered_set<int> ParentStorage::getAncestorsOf(int stm)
 	return the list of statements that is the descendants of the statement specified
 	return an empty set if 'stm' is not found
 */
-unordered_set<int> ParentStorage::getDescendantsOf(int stm)
+unordered_set<int> ParentStorage::getDescendants(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
 	{
@@ -158,22 +161,22 @@ unordered_set<int> ParentStorage::getDescendantsOf(int stm)
 	return {};
 }
 
-unordered_set<int> ParentStorage::getParentList()
+unordered_set<int> ParentStorage::getAllParent()
 {
 	return parentList;
 }
 
-unordered_set<int> ParentStorage::getChildrenList()
+unordered_set<int> ParentStorage::getAllChildren()
 {
 	return childrenList;
 }
 
-unordered_set<pair<int, int>, intPairhash> ParentStorage::getParent_ChildList()
+unordered_set<pair<int, int>, intPairhash> ParentStorage::getParentChildPairs()
 {
 	return parent_ChildPairList;
 }
 
-unordered_set<pair<int, int>, intPairhash> ParentStorage::getAnc_DescList()
+unordered_set<pair<int, int>, intPairhash> ParentStorage::getAncDescPair()
 {
 	return anc_DescPairList;
 }

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -10,11 +10,6 @@ ParentStorage::ParentStorage()
 {
 }
 
-/*
-	Adds the parent relation into the various lists in the storage
-	Returns false if	1) the pair is already stored
-						2) the child already has another parent
-*/
 bool ParentStorage::addParent_Child(int parent, int child)
 {
 	// if Parent-Child Pair is already added
@@ -46,11 +41,6 @@ bool ParentStorage::addParent_Child(int parent, int child)
 	return true;
 }
 
-/*
-	Sets "ancestors" of 'descendant'
-	Each ancestor - descendant pair is entered into anc_DescPairList
-	If 'descendant' already has a list of ancestors, it is not replaced and it return false
-*/
 bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 {
 	if (parentTable.find(descendant)->second.ancestors.size() != 0)
@@ -66,11 +56,6 @@ bool ParentStorage::setAncestors(int descendant, unordered_set<int> ancestors)
 	return true;
 }
 
-/*
-	Sets "descendants" of 'ancestor'
-	Each ancestor - descendant pair is entered into anc_DescPairList
-	If 'ancestor' already has a list of descendants, it is not replaced and it return false
-*/
 bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 {
 	if (parentTable.find(ancestor)->second.descendants.size() != 0)
@@ -86,34 +71,26 @@ bool ParentStorage::setDescendants(int ancestor, unordered_set<int> descendants)
 	return true;
 }
 
-// return true if parentTable is empty
 bool ParentStorage::isEmpty()
 {
 	return parentTable.size() == 0;
 }
 
-// returns true if the specified statement is a parent of another
 bool ParentStorage::isParent(int stm)
 {
 	return parentList.find(stm) != parentList.end();
 }
 
-// returns true if the specified statement is a child of another
 bool ParentStorage::isChild(int stm)
 {
 	return childrenList.find(stm) != childrenList.end();
 }
 
-// returns true if the specified parent* pair is found
 bool ParentStorage::hasAncDescPair(pair<int, int> pair)
 {
 	return anc_DescPairList.find(pair) != anc_DescPairList.end();
 }
 
-/*
-	return the statement that is the parent of 'stm'
-	return 0 if 'stm' is not found
-*/
 int ParentStorage::getParent(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
@@ -123,10 +100,6 @@ int ParentStorage::getParent(int stm)
 	return 0;
 }
 
-/*
-	return the list of statements that is the children of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getChildren(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
@@ -136,10 +109,6 @@ unordered_set<int> ParentStorage::getChildren(int stm)
 	return {};
 }
 
-/*
-	return the list of statements that is the ancestor of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getAncestors(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
@@ -149,10 +118,6 @@ unordered_set<int> ParentStorage::getAncestors(int stm)
 	return {};
 }
 
-/*
-	return the list of statements that is the descendants of 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<int> ParentStorage::getDescendants(int stm)
 {
 	if (parentTable.find(stm) != parentTable.end())
@@ -162,25 +127,21 @@ unordered_set<int> ParentStorage::getDescendants(int stm)
 	return {};
 }
 
-// returns a list of all statements that is the parent of another
 unordered_set<int> ParentStorage::getAllParent()
 {
 	return parentList;
 }
 
-// returns a list of all statements that is the child of another
 unordered_set<int> ParentStorage::getAllChildren()
 {
 	return childrenList;
 }
 
-// returns a list of all parent pairs
 unordered_set<pair<int, int>, intPairhash> ParentStorage::getParentChildPairs()
 {
 	return parent_ChildPairList;
 }
 
-// returns a list of all parent* pairs
 unordered_set<pair<int, int>, intPairhash> ParentStorage::getAncDescPair()
 {
 	return anc_DescPairList;

--- a/Code/source/ParentStorage.cpp
+++ b/Code/source/ParentStorage.cpp
@@ -5,7 +5,6 @@ unordered_set< pair<int, int>, intPairhash> ParentStorage::parent_ChildPairList;
 unordered_set< pair<int, int>, intPairhash> ParentStorage::anc_DescPairList;
 unordered_set<int> ParentStorage::parentList;
 unordered_set<int> ParentStorage::childrenList;
-unordered_set<int> ParentStorage::rootList;
 
 ParentStorage::ParentStorage()
 {
@@ -34,24 +33,10 @@ bool ParentStorage::addParent_Child(int parent, int child)
 	else if (!itrpr.second)		// if child exist but does not have parent initialized
 	{
 		itrpr.first->second.parent = parent;
-		if (rootList.find(child) != rootList.end())	//if child was a root
-		{
-			rootList.erase(child);
-			int root = parent;
-			while (parentTable.find(root)->second.parent != 0)	//while root has a parent
-			{
-				root = parentTable.find(root)->second.parent;
-			}
-			rootList.emplace(root);
-		}
 	}
 
 	// if a new parent statement is added into the table, add to the root list
-	if (parentTable.emplace(parent, pRelationships{ 0, {child}, {}, {} }).second)
-	{
-		rootList.emplace(parent);
-	}
-	else
+	if (!parentTable.emplace(parent, pRelationships{ 0, {child}, {}, {} }).second)
 	{
 		parentTable.find(parent)->second.children.emplace(child);
 	}
@@ -191,9 +176,4 @@ unordered_set<pair<int, int>, intPairhash> ParentStorage::getParent_ChildList()
 unordered_set<pair<int, int>, intPairhash> ParentStorage::getAnc_DescList()
 {
 	return anc_DescPairList;
-}
-
-unordered_set<int> ParentStorage::getRootList()
-{
-	return rootList;
 }

--- a/Code/source/ParentStorage.h
+++ b/Code/source/ParentStorage.h
@@ -37,17 +37,16 @@ public:
 	bool isEmpty();
 	bool isParent(int stm);
 	bool isChild(int stm);
-	bool containsAnc_Desc(pair<int, int> pair);
+	bool hasAncDescPair(pair<int, int> pair);
 
-	int getParentOf(int stm);
-	unordered_set<int> getChildrenOf(int stm);
-	unordered_set<int> getAncestorsOf(int stm);
-	unordered_set<int> getDescendantsOf(int stm);
-	unordered_set<int> getParentList();
-	unordered_set<int> getChildrenList();
-	unordered_set< pair<int, int>, intPairhash> getParent_ChildList();
-	unordered_set< pair<int, int>, intPairhash> getAnc_DescList();
-	unordered_set<int> getRootList();
+	int getParent(int stm);
+	unordered_set<int> getChildren(int stm);
+	unordered_set<int> getAncestors(int stm);
+	unordered_set<int> getDescendants(int stm);
+	unordered_set<int> getAllParent();
+	unordered_set<int> getAllChildren();
+	unordered_set< pair<int, int>, intPairhash> getParentChildPairs();
+	unordered_set< pair<int, int>, intPairhash> getAncDescPair();
 
 private:
 	static unordered_map<int, pRelationships> parentTable;
@@ -55,5 +54,4 @@ private:
 	static unordered_set< pair<int, int>, intPairhash> anc_DescPairList;
 	static unordered_set<int> parentList;
 	static unordered_set<int> childrenList;
-	static unordered_set<int> rootList;
 };

--- a/Code/source/ParentStorage.h
+++ b/Code/source/ParentStorage.h
@@ -30,22 +30,73 @@ class ParentStorage {
 public:
 	ParentStorage();
 
+	/*
+		Adds the parent relation into the various lists in the storage
+		Returns false if	1) the pair is already stored
+							2) the child already has another parent
+	*/
 	bool addParent_Child(int parent, int child);
+
+	/*
+		Sets "ancestors" of 'descendant'
+		Each ancestor - descendant pair is entered into anc_DescPairList
+		If 'descendant' already has a list of ancestors, it is not replaced and it return false
+	*/
 	bool setAncestors(int descendant, unordered_set<int> ancestors);
+
+	/*
+		Sets "descendants" of 'ancestor'
+		Each ancestor - descendant pair is entered into anc_DescPairList
+		If 'ancestor' already has a list of descendants, it is not replaced and it return false
+	*/
 	bool setDescendants(int ancestor, unordered_set<int> descendants);
 
+	// return true if parentTable is empty
 	bool isEmpty();
+
+	// returns true if the specified statement is a parent of another
 	bool isParent(int stm);
+
+	// returns true if the specified statement is a child of another
 	bool isChild(int stm);
+
+	// returns true if the specified parent* pair is found
 	bool hasAncDescPair(pair<int, int> pair);
 
+	/*
+		return the statement that is the parent of 'stm'
+		return 0 if 'stm' is not found
+	*/
 	int getParent(int stm);
+
+	/*
+		return the list of statements that is the children of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getChildren(int stm);
+
+	/*
+		return the list of statements that is the ancestor of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getAncestors(int stm);
+
+	/*
+		return the list of statements that is the descendants of 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<int> getDescendants(int stm);
+
+	// returns a list of all statements that is the parent of another
 	unordered_set<int> getAllParent();
+
+	// returns a list of all statements that is the child of another
 	unordered_set<int> getAllChildren();
+
+	// returns a list of all parent pairs
 	unordered_set< pair<int, int>, intPairhash> getParentChildPairs();
+
+	// returns a list of all parent* pairs
 	unordered_set< pair<int, int>, intPairhash> getAncDescPair();
 
 private:

--- a/Code/source/Parser.cpp
+++ b/Code/source/Parser.cpp
@@ -113,7 +113,7 @@ void Parser::extractAssignEntity(std::string &stmtString, PKB &pkb, int stmtLine
 
 	//Add Variable and Modify
 	pkb.addVariable(modified);
-	pkb.addModifies(stmtLine, modified);
+	pkb.addModifiesStm(stmtLine, modified);
 
 	//Add Constants
 	for (string constant : usedConstants) {
@@ -123,7 +123,7 @@ void Parser::extractAssignEntity(std::string &stmtString, PKB &pkb, int stmtLine
 	//Add Variable and Uses.
 	for (string variable : usedVariables) {
 		pkb.addVariable(variable);
-		pkb.addUses(stmtLine, variable);
+		pkb.addUsesStm(stmtLine, variable);
 	}
 
 	pkb.addAssign(stmtLine, modified, prefixExpression);
@@ -133,7 +133,7 @@ void Parser::extractReadEntity(std::string &stmtString, PKB &pkb, int stmtLine) 
 	ReadParser rp;
 	string modified = rp.parseReadStmt(stmtString);
 
-	pkb.addModifies(stmtLine, modified);
+	pkb.addModifiesStm(stmtLine, modified);
 	pkb.addVariable(modified);
 }
 
@@ -141,7 +141,7 @@ void Parser::extractPrintEntity(std::string &stmtString, PKB &pkb, int stmtLine)
 	PrintParser pp;
 	string used = pp.parsePrintStmt(stmtString);
 
-	pkb.addUses(stmtLine, used);
+	pkb.addUsesStm(stmtLine, used);
 	pkb.addVariable(used);
 }
 
@@ -152,7 +152,7 @@ void Parser::extractWhileEntity(std::string &stmtString, PKB &pkb, int stmtLine,
 
 	for (string variable : variables) {
 		pkb.addVariable(variable);
-		pkb.addUses(stmtLine, variable);
+		pkb.addUsesStm(stmtLine, variable);
 	}
 
 	for (string constant : constants) {
@@ -169,7 +169,7 @@ void Parser::extractIfEntity(std::string &stmtString, PKB &pkb, int stmtLine, ve
 
 	for (string variable : variables) {
 		pkb.addVariable(variable);
-		pkb.addUses(stmtLine, variable);
+		pkb.addUsesStm(stmtLine, variable);
 	}
 
 	for (string constant : constants) {

--- a/Code/source/Parser.cpp
+++ b/Code/source/Parser.cpp
@@ -126,7 +126,7 @@ void Parser::extractAssignEntity(std::string &stmtString, PKB &pkb, int stmtLine
 		pkb.addUsesStm(stmtLine, variable);
 	}
 
-	pkb.addAssign(stmtLine, modified, prefixExpression);
+	pkb.addAssignPattern(stmtLine, modified, prefixExpression);
 }
 
 void Parser::extractReadEntity(std::string &stmtString, PKB &pkb, int stmtLine) {

--- a/Code/source/QueryEvaluator.cpp
+++ b/Code/source/QueryEvaluator.cpp
@@ -394,7 +394,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
-				result = PKB().getModifiedVar(stoi(firstArgument)).size() > 0;
+				result = PKB().getVarModifiedByStm(stoi(firstArgument)).size() > 0;
 				return truthValue(result);
 			}
 		}
@@ -404,7 +404,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
-				result = PKB().getModifiedVar(trimFrontEnd(firstArgument)).size() > 0;
+				result = PKB().getVarModifiedByProc(trimFrontEnd(firstArgument)).size() > 0;
 				return truthValue(result);
 			}
 		}
@@ -548,11 +548,11 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 	else if (relation == "Modifies") {
 		if (isSynonym(secondArgument)) {
 			if (isInteger(firstArgument)) {
-				return PKB().getModifiedVar(stoi(firstArgument));
+				return PKB().getVarModifiedByStm(stoi(firstArgument));
 
 			}
 			else if (isQuoted(firstArgument)) {
-				return PKB().getModifiedVar(trimFrontEnd(firstArgument));
+				return PKB().getVarModifiedByProc(trimFrontEnd(firstArgument));
 			}
 			if (firstArgument == PKB().getProcName()) {
 				return ContainerUtil::to_strset(PKB().getProcVarModifyPairs());

--- a/Code/source/QueryEvaluator.cpp
+++ b/Code/source/QueryEvaluator.cpp
@@ -275,17 +275,17 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(PKB().hasFollowRelation());
 			}
 			else if (isInteger(secondArgument)) {
-				result = PKB().getPrvStm(stoi(secondArgument)) > 0;
+				result = PKB().getStmFollowedBy(stoi(secondArgument)) > 0;
 				return truthValue(result);
 			}
 		}
 		else if (isInteger(firstArgument)) {
 			if (secondArgument == "_") {
-				result = PKB().getNxtStm(stoi(firstArgument)) > 0;
+				result = PKB().getFollower(stoi(firstArgument)) > 0;
 				return truthValue(result);
  			}
 			else if (isInteger(secondArgument)) {
-				result = PKB().getNxtStm(stoi(firstArgument)) == stoi(secondArgument);
+				result = PKB().getFollower(stoi(firstArgument)) == stoi(secondArgument);
 				return truthValue(result);
 			};
 		}
@@ -299,17 +299,17 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(PKB().hasFollowRelation());
 			}
 			else if (isInteger(secondArgument)) {
-				result = PKB().getPrvStm(stoi(secondArgument)) > 0;
+				result = PKB().getStmFollowedBy(stoi(secondArgument)) > 0;
 				return truthValue(result);
 			}
 		}
 		else if (isInteger(firstArgument)) {
 			if (secondArgument == "_") {
-				result = PKB().getNxtStm(stoi(firstArgument)) > 0;
+				result = PKB().getFollower(stoi(firstArgument)) > 0;
 				return truthValue(result);
 			}
 			else if (isInteger(secondArgument)) {
-				result = PKB().hasFollow_S_Pair(stoi(firstArgument), stoi(secondArgument));
+				result = PKB().hasFollowStarPair(stoi(firstArgument), stoi(secondArgument));
 				return truthValue(result);
 			}
 		}
@@ -372,7 +372,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
-				result = PKB().getUsedVar(stoi(firstArgument)).size() > 0;
+				result = PKB().getVarUsedByStm(stoi(firstArgument)).size() > 0;
 				return truthValue(result);
 			}
 		}
@@ -382,7 +382,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
-				result = PKB().getUsedVar(trimFrontEnd(firstArgument)).size() > 0;
+				result = PKB().getVarUsedByProc(trimFrontEnd(firstArgument)).size() > 0;
 				return truthValue(result);
 			}
 		}
@@ -425,7 +425,7 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 				return ContainerUtil::to_strset(PKB().getAllFollowed());
 			}
 			else if (isInteger(secondArgument)) {
-				result.insert(to_string(PKB().getPrvStm(stoi(secondArgument))));
+				result.insert(to_string(PKB().getStmFollowedBy(stoi(secondArgument))));
 			}
 			else {
 				return ContainerUtil::to_strset(PKB().getFollowPairs());
@@ -436,7 +436,7 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 				return ContainerUtil::to_strset(PKB().getAllFollowers());
 			}
 			else if (isInteger(firstArgument)) {
-				result.insert(to_string(PKB().getNxtStm(stoi(firstArgument))));
+				result.insert(to_string(PKB().getFollower(stoi(firstArgument))));
 			}
 			else {
 				return result;
@@ -453,7 +453,7 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 				return ContainerUtil::to_strset(PKB().getAllFollowedBy(stoi(secondArgument)));
 			}
 			else {
-				return ContainerUtil::to_strset(PKB().getFollow_S_Pairs());
+				return ContainerUtil::to_strset(PKB().getFollowStarPairs());
 			}
 		}
 		if (isSynonym(secondArgument)) {
@@ -500,7 +500,7 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 				return ContainerUtil::to_strset(PKB().getAllParents());
 			}
 			else if (isInteger(secondArgument)) {
-				return ContainerUtil::to_strset(PKB().getAllAncestors(stoi(secondArgument)));
+				return ContainerUtil::to_strset(PKB().getAncestors(stoi(secondArgument)));
 			}
 			else {
 				return ContainerUtil::to_strset(PKB().getAncDescPairs());
@@ -511,7 +511,7 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 				return ContainerUtil::to_strset(PKB().getAllChildren());
 			}
 			else if (isInteger(firstArgument)) {
-				return ContainerUtil::to_strset(PKB().getAllDescendants(stoi(firstArgument)));
+				return ContainerUtil::to_strset(PKB().getDescendants(stoi(firstArgument)));
 			}
 			else {
 				return result;
@@ -522,10 +522,10 @@ unordered_set<string> QueryEvaluator::evaluateSuchThat(string relation, string f
 	else if (relation == "Uses") {
 		if (isSynonym(secondArgument)) {
 			if (isInteger(firstArgument)) {
-				return PKB().getUsedVar(stoi(firstArgument));
+				return PKB().getVarUsedByStm(stoi(firstArgument));
 			} 
 			else if (isQuoted(firstArgument)) {
-				return PKB().getUsedVar(trimFrontEnd(firstArgument));
+				return PKB().getVarUsedByProc(trimFrontEnd(firstArgument));
 			}
 			if (firstArgument == PKB().getProcName()) {
 				return ContainerUtil::to_strset(PKB().getProcVarUsePairs());

--- a/Code/source/QueryEvaluator.cpp
+++ b/Code/source/QueryEvaluator.cpp
@@ -368,7 +368,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 	else if (relation == "Uses") {
 		if (isInteger(firstArgument)) {
 			if (isQuoted(secondArgument)) {
-				result = PKB().isUsing(stoi(firstArgument), trimFrontEnd(secondArgument));
+				result = PKB().isStmUsing(stoi(firstArgument), trimFrontEnd(secondArgument));
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
@@ -378,7 +378,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 		}
 		else if (isQuoted(firstArgument)) {
 			if (isQuoted(secondArgument)) {
-				result = PKB().isUsing(trimFrontEnd(firstArgument), trimFrontEnd(secondArgument));
+				result = PKB().isProcUsing(trimFrontEnd(firstArgument), trimFrontEnd(secondArgument));
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
@@ -390,7 +390,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 	else if (relation == "Modifies") {
 		if (isInteger(firstArgument)) {
 			if (isQuoted(secondArgument)) {
-				result = PKB().isModifying(stoi(firstArgument), trimFrontEnd(secondArgument));
+				result = PKB().isStmModifying(stoi(firstArgument), trimFrontEnd(secondArgument));
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {
@@ -400,7 +400,7 @@ string QueryEvaluator::isSuchThatTrivial(string relation, string firstArgument, 
 		}
 		else if (isQuoted(firstArgument)) {
 			if (isQuoted(secondArgument)) {
-				result = PKB().isModifying(trimFrontEnd(firstArgument), trimFrontEnd(secondArgument));
+				result = PKB().isProcModifying(trimFrontEnd(firstArgument), trimFrontEnd(secondArgument));
 				return truthValue(result);
 			}
 			else if (secondArgument == "_") {

--- a/Code/source/UseStorage.cpp
+++ b/Code/source/UseStorage.cpp
@@ -1,110 +1,110 @@
 #include "UseStorage.h"
 
-unordered_set<pair<int, string>, intStringhash> UseStorage::stmVarPairs;
-unordered_set<pair<string, string>, strPairhash> UseStorage::procVarPairs;
-unordered_map<int, unordered_set<string> > UseStorage::varLists_Stm;
-unordered_map<string, unordered_set<string> > UseStorage::varLists_Proc;
-unordered_map<string, unordered_set<int> > UseStorage::stmLists;
-unordered_map<string, unordered_set<string> > UseStorage::procLists;
+unordered_set<pair<int, string>, intStringhash> UseStorage::stmVarPairList;
+unordered_set<pair<string, string>, strPairhash> UseStorage::procVarPairList;
+unordered_map<int, unordered_set<string> > UseStorage::stmToVarMap;
+unordered_map<string, unordered_set<string> > UseStorage::procToVarMap;
+unordered_map<string, unordered_set<int> > UseStorage::varToStmMap;
+unordered_map<string, unordered_set<string> > UseStorage::varToProcMap;
 
 UseStorage::UseStorage()
 {
 }
 
-bool UseStorage::addUses(int stm, string variable)
+bool UseStorage::addUsesStm(int stm, string variable)
 {
-	if (!stmVarPairs.emplace(pair<int, string>(stm, variable)).second)
+	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
 	{
 		return false;
 	}
-	if (!varLists_Stm.emplace(stm, unordered_set<string>{ variable }).second)
+	if (!stmToVarMap.emplace(stm, unordered_set<string>{ variable }).second)
 	{
-		varLists_Stm.at(stm).emplace(variable);
+		stmToVarMap.at(stm).emplace(variable);
 	}
-	if (!stmLists.emplace(variable, unordered_set<int>{ stm }).second)
+	if (!varToStmMap.emplace(variable, unordered_set<int>{ stm }).second)
 	{
-		stmLists.at(variable).emplace(stm);
+		varToStmMap.at(variable).emplace(stm);
 	}
-	if (!stmLists.emplace("", unordered_set<int>{ stm }).second)
+	if (!varToStmMap.emplace("", unordered_set<int>{ stm }).second)
 	{
-		stmLists.at("").emplace(stm);
+		varToStmMap.at("").emplace(stm);
 	}
 	return true;
 }
 
-bool UseStorage::addUses(string procedure, string variable)
+bool UseStorage::addUsesProc(string procedure, string variable)
 {
-	if (!procVarPairs.emplace(pair<string, string>(procedure, variable)).second)
+	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
 	{
 		return false;
 	}
-	if (!varLists_Proc.emplace(procedure, unordered_set<string>{ variable }).second)
+	if (!procToVarMap.emplace(procedure, unordered_set<string>{ variable }).second)
 	{
-		varLists_Proc.at(procedure).emplace(variable);
+		procToVarMap.at(procedure).emplace(variable);
 	}
-	if (!procLists.emplace(variable, unordered_set<string>{ procedure }).second)
+	if (!varToProcMap.emplace(variable, unordered_set<string>{ procedure }).second)
 	{
-		procLists.at(variable).emplace(procedure);
+		varToProcMap.at(variable).emplace(procedure);
 	}
-	if (!procLists.emplace("", unordered_set<string>{ procedure }).second)
+	if (!varToProcMap.emplace("", unordered_set<string>{ procedure }).second)
 	{
-		procLists.at("").emplace(procedure);
+		varToProcMap.at("").emplace(procedure);
 	}
 	return true;
 }
 
 bool UseStorage::containsStmVarPair(pair<int, string> pair)
 {
-	return stmVarPairs.find(pair) != stmVarPairs.end();
+	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
 bool UseStorage::containsProcVarPair(pair<string, string> pair)
 {
-	return procVarPairs.find(pair) != procVarPairs.end();
+	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
-unordered_set<string> UseStorage::getVarUsedBy(int stm)
+unordered_set<string> UseStorage::getVarUsedByStm(int stm)
 {
-	if (varLists_Stm.find(stm) != varLists_Stm.end())
+	if (stmToVarMap.find(stm) != stmToVarMap.end())
 	{
-		return varLists_Stm.at(stm);
+		return stmToVarMap.at(stm);
 	}
 	return {};
 }
 
-unordered_set<string> UseStorage::getVarUsedBy(string proc)
+unordered_set<string> UseStorage::getVarUsedByProc(string proc)
 {
-	if (varLists_Proc.find(proc) != varLists_Proc.end())
+	if (procToVarMap.find(proc) != procToVarMap.end())
 	{
-		return varLists_Proc.at(proc);
+		return procToVarMap.at(proc);
 	}
 	return {};
 }
 
 unordered_set<int> UseStorage::getStmUsing(string variable)
 {
-	if (stmLists.find(variable) != stmLists.end())
+	if (varToStmMap.find(variable) != varToStmMap.end())
 	{
-		return stmLists.at(variable);
+		return varToStmMap.at(variable);
 	}
 	return {};
 }
 
 unordered_set<string> UseStorage::getProcUsing(string variable)
 {
-	if (procLists.find(variable) != procLists.end())
+	if (varToProcMap.find(variable) != varToProcMap.end())
 	{
-		return procLists.at(variable);
+		return varToProcMap.at(variable);
 	}
 	return {};
 }
 
 unordered_set<pair<int, string>, intStringhash> UseStorage::getStmVarPairs()
 {
-	return stmVarPairs;
+	return stmVarPairList;
 }
 
 unordered_set<pair<string, string>, strPairhash> UseStorage::getProcVarPairs()
 {
-	return procVarPairs;
+	return procVarPairList;
 }

--- a/Code/source/UseStorage.cpp
+++ b/Code/source/UseStorage.cpp
@@ -11,6 +11,10 @@ UseStorage::UseStorage()
 {
 }
 
+/*
+	add the Uses relation for a statement into the relevant lists and maps in the storage
+	Returns false if the pair is already exist
+*/
 bool UseStorage::addUsesStm(int stm, string variable)
 {
 	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
@@ -32,6 +36,10 @@ bool UseStorage::addUsesStm(int stm, string variable)
 	return true;
 }
 
+/*
+	add the Uses relation for a procedure into the relevant lists and maps in the storage
+	Returns false if the pair is already exist
+*/
 bool UseStorage::addUsesProc(string procedure, string variable)
 {
 	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
@@ -53,16 +61,22 @@ bool UseStorage::addUsesProc(string procedure, string variable)
 	return true;
 }
 
+// returns true if the specified <statement, variable> pair is found
 bool UseStorage::containsStmVarPair(pair<int, string> pair)
 {
 	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
+// returns true if the specified <procedure, variable> pair is found
 bool UseStorage::containsProcVarPair(pair<string, string> pair)
 {
 	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
+/*
+	return the list of variables that is used by 'stm'
+	return an empty set if 'stm' is not found
+*/
 unordered_set<string> UseStorage::getVarUsedByStm(int stm)
 {
 	if (stmToVarMap.find(stm) != stmToVarMap.end())
@@ -72,15 +86,23 @@ unordered_set<string> UseStorage::getVarUsedByStm(int stm)
 	return {};
 }
 
-unordered_set<string> UseStorage::getVarUsedByProc(string proc)
+/*
+	return the list of variables that is used by 'procedure'
+	return an empty set if 'procedure' is not found
+*/
+unordered_set<string> UseStorage::getVarUsedByProc(string procedure)
 {
-	if (procToVarMap.find(proc) != procToVarMap.end())
+	if (procToVarMap.find(procedure) != procToVarMap.end())
 	{
-		return procToVarMap.at(proc);
+		return procToVarMap.at(procedure);
 	}
 	return {};
 }
 
+/*
+	return the list of statements that is using 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<int> UseStorage::getStmUsing(string variable)
 {
 	if (varToStmMap.find(variable) != varToStmMap.end())
@@ -90,6 +112,10 @@ unordered_set<int> UseStorage::getStmUsing(string variable)
 	return {};
 }
 
+/*
+	return the list of procedures that is using 'variable'
+	return an empty set if 'variable' is not found
+*/
 unordered_set<string> UseStorage::getProcUsing(string variable)
 {
 	if (varToProcMap.find(variable) != varToProcMap.end())
@@ -99,11 +125,13 @@ unordered_set<string> UseStorage::getProcUsing(string variable)
 	return {};
 }
 
+// returns a list of all Uses pairs for statements
 unordered_set<pair<int, string>, intStringhash> UseStorage::getStmVarPairs()
 {
 	return stmVarPairList;
 }
 
+// returns a list of all Uses pairs for procedures
 unordered_set<pair<string, string>, strPairhash> UseStorage::getProcVarPairs()
 {
 	return procVarPairList;

--- a/Code/source/UseStorage.cpp
+++ b/Code/source/UseStorage.cpp
@@ -11,10 +11,6 @@ UseStorage::UseStorage()
 {
 }
 
-/*
-	add the Uses relation for a statement into the relevant lists and maps in the storage
-	Returns false if the pair is already exist
-*/
 bool UseStorage::addUsesStm(int stm, string variable)
 {
 	if (!stmVarPairList.emplace(pair<int, string>(stm, variable)).second)
@@ -36,10 +32,6 @@ bool UseStorage::addUsesStm(int stm, string variable)
 	return true;
 }
 
-/*
-	add the Uses relation for a procedure into the relevant lists and maps in the storage
-	Returns false if the pair is already exist
-*/
 bool UseStorage::addUsesProc(string procedure, string variable)
 {
 	if (!procVarPairList.emplace(pair<string, string>(procedure, variable)).second)
@@ -61,22 +53,16 @@ bool UseStorage::addUsesProc(string procedure, string variable)
 	return true;
 }
 
-// returns true if the specified <statement, variable> pair is found
 bool UseStorage::containsStmVarPair(pair<int, string> pair)
 {
 	return stmVarPairList.find(pair) != stmVarPairList.end();
 }
 
-// returns true if the specified <procedure, variable> pair is found
 bool UseStorage::containsProcVarPair(pair<string, string> pair)
 {
 	return procVarPairList.find(pair) != procVarPairList.end();
 }
 
-/*
-	return the list of variables that is used by 'stm'
-	return an empty set if 'stm' is not found
-*/
 unordered_set<string> UseStorage::getVarUsedByStm(int stm)
 {
 	if (stmToVarMap.find(stm) != stmToVarMap.end())
@@ -86,10 +72,6 @@ unordered_set<string> UseStorage::getVarUsedByStm(int stm)
 	return {};
 }
 
-/*
-	return the list of variables that is used by 'procedure'
-	return an empty set if 'procedure' is not found
-*/
 unordered_set<string> UseStorage::getVarUsedByProc(string procedure)
 {
 	if (procToVarMap.find(procedure) != procToVarMap.end())
@@ -99,10 +81,6 @@ unordered_set<string> UseStorage::getVarUsedByProc(string procedure)
 	return {};
 }
 
-/*
-	return the list of statements that is using 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<int> UseStorage::getStmUsing(string variable)
 {
 	if (varToStmMap.find(variable) != varToStmMap.end())
@@ -112,10 +90,6 @@ unordered_set<int> UseStorage::getStmUsing(string variable)
 	return {};
 }
 
-/*
-	return the list of procedures that is using 'variable'
-	return an empty set if 'variable' is not found
-*/
 unordered_set<string> UseStorage::getProcUsing(string variable)
 {
 	if (varToProcMap.find(variable) != varToProcMap.end())
@@ -125,13 +99,11 @@ unordered_set<string> UseStorage::getProcUsing(string variable)
 	return {};
 }
 
-// returns a list of all Uses pairs for statements
 unordered_set<pair<int, string>, intStringhash> UseStorage::getStmVarPairs()
 {
 	return stmVarPairList;
 }
 
-// returns a list of all Uses pairs for procedures
 unordered_set<pair<string, string>, strPairhash> UseStorage::getProcVarPairs()
 {
 	return procVarPairList;

--- a/Code/source/UseStorage.h
+++ b/Code/source/UseStorage.h
@@ -17,16 +17,52 @@ class UseStorage
 public:
 	UseStorage();
 
+	/*
+		add the Uses relation for a statement into the relevant lists and maps in the storage
+		Returns false if the pair is already exist
+	*/
 	bool addUsesStm(int stm, string variable);
+
+	/*
+		add the Uses relation for a procedure into the relevant lists and maps in the storage
+		Returns false if the pair is already exist
+	*/
 	bool addUsesProc(string procedure, string variable);
 
+	// returns true if the specified <statement, variable> pair is found
 	bool containsStmVarPair(pair<int, string> pair);
+
+	// returns true if the specified <procedure, variable> pair is found
 	bool containsProcVarPair(pair<string, string> pair);
+
+	/*
+		return the list of variables that is used by 'stm'
+		return an empty set if 'stm' is not found
+	*/
 	unordered_set<string> getVarUsedByStm(int stm);
+
+	/*
+		return the list of variables that is used by 'procedure'
+		return an empty set if 'procedure' is not found
+	*/
 	unordered_set<string> getVarUsedByProc(string proc);
+
+	/*
+		return the list of statements that is using 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<int> getStmUsing(string variable);
+
+	/*
+		return the list of procedures that is using 'variable'
+		return an empty set if 'variable' is not found
+	*/
 	unordered_set<string> getProcUsing(string variable);
+
+	// returns a list of all Uses pairs for statements
 	unordered_set< pair<int, string>, intStringhash> getStmVarPairs();
+
+	// returns a list of all Uses pairs for procedures
 	unordered_set< pair<string, string>, strPairhash> getProcVarPairs();
 
 private:

--- a/Code/source/UseStorage.h
+++ b/Code/source/UseStorage.h
@@ -5,8 +5,6 @@
 #include <unordered_map>
 #include <utility>
 
-using namespace std;
-
 #include "Hasher.h"
 
 /*
@@ -17,23 +15,23 @@ class UseStorage
 public:
 	UseStorage();
 
-	bool addUses(int stm, string variable);
-	bool addUses(string procedure, string variable);
+	bool addUsesStm(int stm, string variable);
+	bool addUsesProc(string procedure, string variable);
 
 	bool containsStmVarPair(pair<int, string> pair);
 	bool containsProcVarPair(pair<string, string> pair);
-	unordered_set<string> getVarUsedBy(int stm);
-	unordered_set<string> getVarUsedBy(string proc);
+	unordered_set<string> getVarUsedByStm(int stm);
+	unordered_set<string> getVarUsedByProc(string proc);
 	unordered_set<int> getStmUsing(string variable);
 	unordered_set<string> getProcUsing(string variable);
 	unordered_set< pair<int, string>, intStringhash> getStmVarPairs();
 	unordered_set< pair<string, string>, strPairhash> getProcVarPairs();
 
 private:
-	static unordered_set<pair<int, string>, intStringhash> stmVarPairs;
-	static unordered_set<pair<string, string>, strPairhash> procVarPairs;
-	static unordered_map<int, unordered_set<string> > varLists_Stm;
-	static unordered_map<string, unordered_set<string> > varLists_Proc;
-	static unordered_map<string, unordered_set<int> > stmLists;
-	static unordered_map<string, unordered_set<string> > procLists;
+	static unordered_set<pair<int, string>, intStringhash> stmVarPairList;
+	static unordered_set<pair<string, string>, strPairhash> procVarPairList;
+	static unordered_map<int, unordered_set<string> > stmToVarMap;
+	static unordered_map<string, unordered_set<string> > procToVarMap;
+	static unordered_map<string, unordered_set<int> > varToStmMap;
+	static unordered_map<string, unordered_set<string> > varToProcMap;
 };

--- a/Code/source/UseStorage.h
+++ b/Code/source/UseStorage.h
@@ -36,25 +36,27 @@ public:
 	bool containsProcVarPair(pair<string, string> pair);
 
 	/*
-		return the list of variables that is used by 'stm'
+		return a list of variables that is used by 'stm'
 		return an empty set if 'stm' is not found
 	*/
 	unordered_set<string> getVarUsedByStm(int stm);
 
 	/*
-		return the list of variables that is used by 'procedure'
+		return a list of variables that is used by 'procedure'
 		return an empty set if 'procedure' is not found
 	*/
 	unordered_set<string> getVarUsedByProc(string proc);
 
 	/*
-		return the list of statements that is using 'variable'
+		return a list of statements that is using 'variable'
+		returns a list of all statements that used a variable if 'variable' == "" 
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<int> getStmUsing(string variable);
 
 	/*
-		return the list of procedures that is using 'variable'
+		return a list of procedures that is using 'variable'
+		returns a list of all procedures that used a variable if 'variable' == ""
 		return an empty set if 'variable' is not found
 	*/
 	unordered_set<string> getProcUsing(string variable);

--- a/Code/source/UseStorage.h
+++ b/Code/source/UseStorage.h
@@ -5,6 +5,8 @@
 #include <unordered_map>
 #include <utility>
 
+using namespace std;
+
 #include "Hasher.h"
 
 /*


### PR DESCRIPTION
1. filtered out the header files. Moved ContainerUtil and printParser to utilities and parser folders respectively

2. Changed return type of pattern methods to unordered_set

3. PKB now stores a list of procedures  (build will fail due to this change, require PQL to change)
    getProcName has been changed to getProcList to reflect this. Return type is unordered_set<string>

4. renamed PKB methods (refactoring has been done to rename them everywhere)
Methods of the Storage classes have also been renamed to be exactly the same for consistency

Before | After
------- | -------
**setFollowers** | **setAllFollowing**
**setStmFollowedBy** | **setAllFollowedBy**
hasFollow_S_Pair | hasFollowStarPair
getNxtStm | getFollower
getPrvStm | getStmFollowedBy
getFollow_S_Pairs | getFollowStarPairs
getAllAncestors | getAncestors
getAllDscendants  | getDescendants
addUses  | addUsesStm   &   addUsesProc
addModifies  | addModifiesStm   &   addModifiesProc
getUsedVar | getVarUsedBySm   &   getVarUsedByProc
getModifiedVar | getVarModifiedByStm    &    getVarModifiedByProc
**isUsing** | **isStmUsing     &    isProcUsing**
**isModifying** | **isStmModifying    &     isProcModifying**
**addAssign** | **addAssignPattern**

5. Renamed fields (was in the original changes but I failed to mention)
They are changes made in UseStorage and ModifyStorage

Before | After
------- | -------
stmVarPairs | stmVarPairList
procVarPairs | procVarPairList
varLists_Stm | stmToVarMap
varLists_Proc | procToVarMap
stmLists | varToStmMap
procLists | varToProcMap

6. removed unused root method

**7. Comments has been added in PKB, FollowStorage, ParentStorage, UseStorage and ModifyStorage**
