### PR TITLE
Bug fix

### DIFF
--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -237,6 +237,10 @@ int PKB::getTotalStmNo()
 
 stmType PKB::getStmType(int stm)
 {
+	if (stm <= 0 || stm >= stmTypeList.size())
+	{
+		return none;
+	}
 	return stmTypeList.at(stm);
 }
 

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -31,8 +31,7 @@ void PKB::addProc(string name)
 
 void PKB::addStatement(int stmNo, stmType type)
 {
-	stmTypeList.assign(stmNo, type);
-
+	stmTypeList.push_back(type);
 	switch (type)
 	{
 		case read:
@@ -60,7 +59,7 @@ void PKB::addStatement(int stmNo, stmType type)
 
 void PKB::addStatement(int stmNo, stmType type, string procedure)
 {
-	stmTypeList.assign(stmNo, type);
+	stmTypeList.push_back(type);
 	if (!procStmList.emplace(procedure, vector<int>{stmNo}).second)
 	{
 		procStmList.find(procedure)->second.push_back(stmNo);

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -14,7 +14,7 @@ using namespace std;
 #include "NextStorage.h"
 #include "Hasher.h"
 
-enum stmType { read, print, assign, whileStm, ifStm, call};
+enum stmType {none, read, print, assign, whileStm, ifStm, call};
 
 /*
 	Accepts relationship, pattern and other general data from Parser and DesignExtractor and

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -31,10 +31,15 @@ public:
 	// add a procedure to procList
 	void addProc(string procName);
 
-	//add statement to its respective StmList and set stmTypeList[stmNo] to type 
+	/*
+		Pre-cond: statements added in must be added in numerical order; no jumps or reversing
+		add statement to its respective StmList and set stmTypeList[stmNo] to type 
+	*/
 	void addStatement(int stmNo, stmType type);
-
-	//add statement to its respective StmLists and set stmTypeList[stmNo] to type 
+	/*
+		Pre-cond: statements added in must be added in numerical order; no jumps or reversing
+		add statement to its respective StmLists and set stmTypeList[stmNo] to type
+	*/
 	void addStatement(int stmNo, stmType type, string procedure);
 
 	// add variable to varList


### PR DESCRIPTION
Fix bug where addStatement will assign all values from index 0 to 'stmNo' to the specified stmType. The method will now add to the back of the vector. However this is under the assumption that addStatement will only add statements in a numerical order

Fix bug where getStmType goes out of bounds. Added a check which will return a special stmType, 'none' to show that the stm specified is not in the list