### PR TITLE
Iteration 2 : PKB While/If Control Variable Storage

### DIFF
--- a/Code/SPA/SPA.vcxproj
+++ b/Code/SPA/SPA.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="..\source\CallStorage.cpp" />
     <ClCompile Include="..\source\ConditionalExp.cpp" />
     <ClCompile Include="..\source\ContainerUtil.cpp" />
+    <ClCompile Include="..\source\ControlVariableStorage.cpp" />
     <ClCompile Include="..\source\DesignExtractor.cpp" />
     <ClCompile Include="..\source\ElseParser.cpp" />
     <ClCompile Include="..\source\ExpressionUtil.cpp" />
@@ -46,6 +47,7 @@
     <ClInclude Include="..\source\CallStorage.h" />
     <ClInclude Include="..\source\ConditionalExp.h" />
     <ClInclude Include="..\source\ContainerUtil.h" />
+    <ClInclude Include="..\source\ControlVariableStorage.h" />
     <ClInclude Include="..\source\DesignExtractor.h" />
     <ClInclude Include="..\source\ElseParser.h" />
     <ClInclude Include="..\source\ExpressionUtil.h" />

--- a/Code/SPA/SPA.vcxproj.filters
+++ b/Code/SPA/SPA.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="..\source\RunTimeDesignExtractor.cpp">
       <Filter>Source Files\DesignExtractor</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\ControlVariableStorage.cpp">
+      <Filter>Source Files\PKB</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\source\PKB.h">
@@ -229,6 +232,9 @@
     </ClInclude>
     <ClInclude Include="..\source\RunTimeDesignExtractor.h">
       <Filter>Header Files\DesignExtractor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\ControlVariableStorage.h">
+      <Filter>Header Files\PKB</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Code/source/ControlVariableStorage.cpp
+++ b/Code/source/ControlVariableStorage.cpp
@@ -1,0 +1,91 @@
+#include "ControlVariableStorage.h"
+
+std::unordered_map<std::string, std::unordered_set<int>> ControlVariableStorage::ifVariableToStm;
+std::unordered_map<std::string, std::unordered_set<int>> ControlVariableStorage::whileVariableToStm;
+
+ControlVariableStorage::ControlVariableStorage() {
+
+}
+
+void ControlVariableStorage::addIfControlVariable(int stm, string variable) {
+
+	//if cannot find key
+	if (ifVariableToStm.find(variable) == ifVariableToStm.end()) {
+		std::unordered_set<int> stmList;
+		stmList.insert(stm);
+		ifVariableToStm[variable] = stmList;
+	} else {
+		std::unordered_set<int> stmList = ifVariableToStm[variable];
+		stmList.insert(stm);
+		ifVariableToStm[variable] = stmList;
+	}
+}
+
+void ControlVariableStorage::addWhileControlVariable(int stm, string variable) {
+
+	//If cannot find key
+	if (whileVariableToStm.find(variable) == whileVariableToStm.end()) {
+		std::unordered_set<int> stmList;
+		stmList.insert(stm);
+		whileVariableToStm[variable] = stmList;
+	} else {
+		std::unordered_set<int> stmList = whileVariableToStm[variable];
+		stmList.insert(stm);
+		whileVariableToStm[variable] = stmList;
+	}
+}
+
+bool ControlVariableStorage::hasIfControlVariable() {
+
+	if (ifVariableToStm.empty()) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+bool ControlVariableStorage::hasWhileControlVariable() {
+
+	if (whileVariableToStm.empty()) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+std::unordered_set<int> ControlVariableStorage::getIfStmWithControlVariable(std::string variable) {
+
+	return ifVariableToStm[variable];
+
+}
+
+std::unordered_set<int> ControlVariableStorage::getWhileStmWithControlVariable(std::string variable) {
+
+	return whileVariableToStm[variable];
+
+}
+
+std::unordered_set<std::pair<int, std::string>, intStringhash> ControlVariableStorage::getIfStmControlVariablePair() {
+
+	std::unordered_set<std::pair<int, std::string>, intStringhash> result;
+
+	for (std::pair<std::string, std::unordered_set<int>> pair : ifVariableToStm) {
+		for (int stm : pair.second) {
+			result.insert(std::make_pair(stm, pair.first));
+		}
+	}
+	return result;
+}
+
+std::unordered_set<std::pair<int, std::string>, intStringhash> ControlVariableStorage::getWhileStmControlVariablePair()
+{
+	std::unordered_set<std::pair<int, std::string>, intStringhash> result;
+
+	for (std::pair<std::string, std::unordered_set<int>> pair : whileVariableToStm) {
+		for (int stm : pair.second) {
+			result.insert(std::make_pair(stm, pair.first));
+		}
+	}
+	return result;
+}
+

--- a/Code/source/ControlVariableStorage.h
+++ b/Code/source/ControlVariableStorage.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <unordered_set>
+#include <unordered_map>
+
+
+#include "Hasher.h"
+
+class ControlVariableStorage {
+
+public:
+	ControlVariableStorage();
+	void addIfControlVariable(int stm, string variable);
+	void addWhileControlVariable(int stm, string variable);
+
+	//Call for if(_,_)
+	bool hasIfControlVariable();
+
+	//Call for w(_,_)
+	bool hasWhileControlVariable();
+
+	//Call for if('s',_)
+	std::unordered_set<int> getIfStmWithControlVariable(std::string variable);
+
+	//Call for w('s',_)
+	std::unordered_set <int> getWhileStmWithControlVariable(std::string variable);
+
+	//Call for if(s,_)
+	std::unordered_set<std::pair<int, std::string>, intStringhash> getIfStmControlVariablePair();
+
+	//Call for w(s,_)
+	std::unordered_set<std::pair<int, std::string>, intStringhash> getWhileStmControlVariablePair();
+
+private:
+	static std::unordered_map<std::string, std::unordered_set<int>> ifVariableToStm;
+	static std::unordered_map<std::string, std::unordered_set<int>> whileVariableToStm;
+};

--- a/Code/source/PKB.cpp
+++ b/Code/source/PKB.cpp
@@ -19,6 +19,7 @@ UseStorage PKB::uStore;
 ModifyStorage PKB::mStore;
 CallStorage PKB::cStore;
 NextStorage PKB::nStore;
+ControlVariableStorage PKB::cvStore;
 unordered_map<int, pair<string, string> > PKB::patternList;
 
 PKB::PKB()
@@ -647,4 +648,44 @@ unordered_set<pair<int, string>, intStringhash> PKB::findPatternPairs(string exp
 		}
 	}
 	return validPairs;
+}
+
+void PKB::addIfControlVariable(int stm, string variable)
+{
+	cvStore.addIfControlVariable(stm, variable);
+}
+
+void PKB::addWhileControlVariable(int stm, string variable)
+{
+	cvStore.addWhileControlVariable(stm, variable);
+}
+
+bool PKB::hasIfControlVariable()
+{
+	return cvStore.hasIfControlVariable();
+}
+
+bool PKB::hasWhileControlVariable()
+{
+	return cvStore.hasWhileControlVariable();
+}
+
+std::unordered_set<int> PKB::getIfStmWithControlVariable(std::string variable)
+{
+	return cvStore.getIfStmWithControlVariable(variable);
+}
+
+std::unordered_set<int> PKB::getWhileStmWithControlVariable(std::string variable)
+{
+	return cvStore.getWhileStmWithControlVariable(variable);
+}
+
+std::unordered_set<std::pair<int, std::string>, intStringhash> PKB::getIfStmControlVariablePair()
+{
+	return cvStore.getIfStmControlVariablePair();
+}
+
+std::unordered_set<std::pair<int, std::string>, intStringhash> PKB::getWhileStmControlVariablePair()
+{
+	return cvStore.getWhileStmControlVariablePair();
 }

--- a/Code/source/PKB.h
+++ b/Code/source/PKB.h
@@ -12,6 +12,7 @@ using namespace std;
 #include "ModifyStorage.h"
 #include "CallStorage.h"
 #include "NextStorage.h"
+#include "ControlVariableStorage.h"
 #include "Hasher.h"
 
 enum stmType {read, print, assign, whileStm, ifStm, call};
@@ -545,6 +546,36 @@ public:
 	*/
 	unordered_set<pair<int, string>, intStringhash> findPatternPairs(string expr, bool isExclusive);
 
+
+
+	/*
+	* While/If Pattern Setters and Getters
+	*/
+
+	//Set for ifs.
+	void addIfControlVariable(int stm, string variable);
+
+	//Set for while.
+	void addWhileControlVariable(int stm, string variable);
+
+	//Call for if(_,_)
+	bool hasIfControlVariable();
+
+	//Call for w(_,_)
+	bool hasWhileControlVariable();
+
+	//Call for if('s',_)
+	std::unordered_set<int> getIfStmWithControlVariable(std::string variable);
+
+	//Call for w('s',_)
+	std::unordered_set <int> getWhileStmWithControlVariable(std::string variable);
+
+	//Call for if(s,_)
+	std::unordered_set<std::pair<int, std::string>, intStringhash> getIfStmControlVariablePair();
+
+	//Call for w(s,_)
+	std::unordered_set<std::pair<int, std::string>, intStringhash> getWhileStmControlVariablePair();
+
 private:
 	static unordered_set<string> procList;
 	static unordered_map<string, vector<int>> procStmList;
@@ -564,5 +595,6 @@ private:
 	static ModifyStorage mStore;
 	static CallStorage cStore;
 	static NextStorage nStore;
+	static ControlVariableStorage cvStore;
 	static unordered_map<int, pair<string, string> > patternList;
 };

--- a/Code/source/Parser.cpp
+++ b/Code/source/Parser.cpp
@@ -43,11 +43,6 @@ int Parser::parse(vector<Statement> stmtLst, int parent, string procedure) {
 			pkb.addNext(stmt.getStmtLst().back().getStmtNum(), currStmtLine);
 		}
 
-		//Add Procedure - Statement Relationship if Statment is in a Procedure.
-		if (!procedure.empty()) {
-			//TODO:: Add Procedure containing statement in pkb.
-		}
-
 		//Add VariableName, Constants, and Procedure name into PKB.
 		populateDesignEntities(stmt, procedure);
 
@@ -169,6 +164,7 @@ void Parser::extractWhileEntity(std::string &stmtString, int stmtLine, vector<St
 	for (string variable : variables) {
 		pkb.addVariable(variable);
 		pkb.addUsesStm(stmtLine, variable);
+		pkb.addWhileControlVariable(stmtLine, variable);
 	}
 
 	for (string constant : constants) {
@@ -186,6 +182,7 @@ void Parser::extractIfEntity(std::string &stmtString, int stmtLine, vector<State
 	for (string variable : variables) {
 		pkb.addVariable(variable);
 		pkb.addUsesStm(stmtLine, variable);
+		pkb.addIfControlVariable(stmtLine, variable);
 	}
 
 	for (string constant : constants) {


### PR DESCRIPTION
1. PKB APIs for While/IfControl Variable Storage
`	/*
	* While/If Pattern Setters and Getters
	*/

	//Set for ifs.
	void addIfControlVariable(int stm, string variable);

	//Set for while.
	void addWhileControlVariable(int stm, string variable);

	//Call for if(_,_)
	bool hasIfControlVariable();

	//Call for w(_,_)
	bool hasWhileControlVariable();

	//Call for if('s',_)
	std::unordered_set<int> getIfStmWithControlVariable(std::string variable);

	//Call for w('s',_)
	std::unordered_set <int> getWhileStmWithControlVariable(std::string variable);

	//Call for if(s,_)
	std::unordered_set<std::pair<int, std::string>, intStringhash> getIfStmControlVariablePair();

	//Call for w(s,_)
	std::unordered_set<std::pair<int, std::string>, intStringhash> getWhileStmControlVariablePair();
`
2. Integrate Parser with new APIs in PKB.

@RomaRomama let me know if you need more apis