### PR TITLE
Changed output type to allow identification of clausetype for evaluator

### DIFF
--- a/Code/UnitTesting/PKB/ModifyStorageTest.cpp
+++ b/Code/UnitTesting/PKB/ModifyStorageTest.cpp
@@ -31,14 +31,14 @@ namespace UnitTesting
 		{
 			ModifyStorage store;
 			store.addModifiesStm(1, "apple");
-			Assert::IsTrue(store.containsStmVarPair(pair<int, string>(1, "apple")));
+			Assert::IsTrue(store.containsStmVarPair(std::pair<int, std::string>(1, "apple")));
 		}
 
 		TEST_METHOD(containsModifyProcPair_PairExist_Success)
 		{
 			ModifyStorage store;
 			store.addModifiesProc("fruit", "apple");
-			Assert::IsTrue(store.containsProcVarPair(pair<string, string>("fruit", "apple")));
+			Assert::IsTrue(store.containsProcVarPair(std::pair<std::string, std::string>("fruit", "apple")));
 		}
 
 		TEST_METHOD(getVarModifiedByStm_NormalOperation_Success)

--- a/Code/UnitTesting/PQL/OptimizerTest.cpp
+++ b/Code/UnitTesting/PQL/OptimizerTest.cpp
@@ -10,7 +10,8 @@ namespace UnitTesting
 	{
 	public:
 		std::vector<std::pair<std::string, std::pair<std::string, std::string>>> empty;
-		std::unordered_set<std::string> s;
+		std::vector<std::pair<std::string, std::string>> wempty;
+		std::vector<std::string> s;
 		std::unordered_map<std::string, std::string> d;
 		TEST_METHOD(testExtractSuchThat1)
 		{
@@ -19,7 +20,7 @@ namespace UnitTesting
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
 			d["s"] = "stmt";
 			st.push_back(clause);
-			Optimizer op = Optimizer(st, empty, empty, s, d);
+			Optimizer op = Optimizer(st, wempty, empty, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractSuchThatSyn(0);
 			std::vector<std::string> vect{ "s" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(49, vect);
@@ -32,7 +33,7 @@ namespace UnitTesting
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
 			d["a"] = "assign";
 			st.push_back(clause);
-			Optimizer op = Optimizer(st, empty, empty, s, d);
+			Optimizer op = Optimizer(st, wempty, empty, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractSuchThatSyn(0);
 			std::vector<std::string> vect{ "a", "s" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(19, vect);
@@ -45,7 +46,7 @@ namespace UnitTesting
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
 			d["p"] = "procedure";
 			st.push_back(clause);
-			Optimizer op = Optimizer(st, empty, empty, s, d);
+			Optimizer op = Optimizer(st, wempty, empty, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractSuchThatSyn(0);
 			std::vector<std::string> vect{ "p" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(23, vect);
@@ -53,9 +54,8 @@ namespace UnitTesting
 		}
 		TEST_METHOD(testExtractWithSynonym1)
 		{
-			std::pair<std::string, std::pair<std::string, std::string>> clause =
-				std::make_pair("with", std::make_pair("a.stmtNum", "14"));
-			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w;
+			std::pair<std::string, std::string> clause = std::make_pair("a.stmtNum", "14");
+			std::vector<std::pair<std::string, std::string>> w;
 			w.push_back(clause);
 			Optimizer op = Optimizer(empty, w, empty, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractWithSyn(0);
@@ -65,9 +65,8 @@ namespace UnitTesting
 		}
 		TEST_METHOD(testExtractWithSynonym2)
 		{
-			std::pair<std::string, std::pair<std::string, std::string>> clause =
-				std::make_pair("with", std::make_pair("pr.varName", "re.varName"));
-			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w;
+			std::pair<std::string, std::string> clause = std::make_pair("pr.varName", "re.varName");
+			std::vector<std::pair<std::string, std::string>> w;
 			w.push_back(clause);
 			d["re"] = "read";
 			d["pr"] = "print";
@@ -86,7 +85,7 @@ namespace UnitTesting
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p;
 			p.push_back(clause);
 			d["a"] = "assign";
-			Optimizer op = Optimizer(empty, empty, p, s, d);
+			Optimizer op = Optimizer(empty, wempty, p, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractPatternSyn(0);
 			std::vector<std::string> vect{ "a" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(44, vect);
@@ -100,7 +99,7 @@ namespace UnitTesting
 			p.push_back(clause);
 			d["ifs"] = "if";
 			d["v"] = "variable";
-			Optimizer op = Optimizer(empty, empty, p, s, d);
+			Optimizer op = Optimizer(empty, wempty, p, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractPatternSyn(0);
 			std::vector<std::string> vect{ "ifs", "v" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(29, vect);
@@ -113,7 +112,7 @@ namespace UnitTesting
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p;
 			d["w"] = "while";
 			p.push_back(clause);
-			Optimizer op = Optimizer(empty, empty, p, s, d);
+			Optimizer op = Optimizer(empty, wempty, p, s, d);
 			std::pair<int, std::vector<std::string>> result = op.extractPatternSyn(0);
 			std::vector<std::string> vect{ "w" };
 			std::pair<int, std::vector<std::string>> expected = std::make_pair(16, vect);
@@ -131,24 +130,34 @@ namespace UnitTesting
 				std::make_pair("Modifies", std::make_pair("s", "v"));
 			std::pair<std::string, std::pair<std::string, std::string>> clause4 =
 				std::make_pair("Parent", std::make_pair("w", "ifs"));
-			std::pair<std::string, std::pair<std::string, std::string>> clause5 =
-				std::make_pair("with", std::make_pair("v.varName", str));
-			std::pair<std::string, std::pair<std::string, std::string>> clause6 =
-				std::make_pair("with", std::make_pair("s.stmt#", "15"));
+			std::pair<std::string, std::string> clause5 = std::make_pair("v.varName", str);
+			std::pair<std::string, std::string> clause6 = std::make_pair("s.stmt#", "15");
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c1 =
+				std::make_pair(std::make_pair("pattern", "w"), std::make_pair("v", "_"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c2 =
+				std::make_pair(std::make_pair("st", "Follows"), std::make_pair("w", "s"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c3 =
+				std::make_pair(std::make_pair("st", "Modifies"), std::make_pair("s", "v"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c4 =
+				std::make_pair(std::make_pair("st", "Parent"), std::make_pair("w", "ifs"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c5 =
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("v.varName", str));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c6 = 
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("s.stmt#", "15"));
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p;
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
-			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w;
+			std::vector<std::pair<std::string, std::string>> w;
 			p.push_back(clause1);
 			st.push_back(clause2); st.push_back(clause3); st.push_back(clause4);
 			w.push_back(clause5); w.push_back(clause6);
-			s.insert("a");
+			s.push_back("a");
 			d["w"] = "while"; d["v"] = "variable"; d["ifs"] = "if"; d["s"] = "stmt";
 			Optimizer op = Optimizer(st, w, p, s, d);
 			op.groupClause();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected1 = { {clause6, clause2, clause1, clause5, clause3, clause4} };
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected2 = { };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected1 = { {c6, c2, c1, c5, c3, c4} };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected2 = { };
 			Assert::IsTrue(result1 == expected1 && result2 == expected2);
 		}
 		TEST_METHOD(testGraphChainingLogic2)
@@ -163,25 +172,35 @@ namespace UnitTesting
 				std::make_pair("Modifies", std::make_pair("p", str1));
 			std::pair<std::string, std::pair<std::string, std::string>> clause4 =
 				std::make_pair("Call", std::make_pair("p", str2));
-			std::pair<std::string, std::pair<std::string, std::string>> clause5 =
-				std::make_pair("with", std::make_pair("v.varName", "q.procName"));
-			std::pair<std::string, std::pair<std::string, std::string>> clause6 =
-				std::make_pair("with", std::make_pair("q.procName", str2));
+			std::pair<std::string, std::string> clause5 = std::make_pair("v.varName", "q.procName");
+			std::pair<std::string, std::string> clause6 = std::make_pair("q.procName", str2);
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c1 =
+				std::make_pair(std::make_pair("pattern", "ifs"), std::make_pair("_", "_"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c2 =
+				std::make_pair(std::make_pair("st", "Follows"), std::make_pair("a", "14"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c3 =
+				std::make_pair(std::make_pair("st", "Modifies"), std::make_pair("p", str1));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c4 =
+				std::make_pair(std::make_pair("st", "Call"), std::make_pair("p", str2));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c5 = 
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("v.varName", "q.procName"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c6 = 
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("q.procName", str2));
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p;
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
-			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w;
+			std::vector<std::pair<std::string, std::string>> w;
 			p.push_back(clause1);
 			st.push_back(clause2); st.push_back(clause3); st.push_back(clause4);
 			w.push_back(clause5); w.push_back(clause6);
 			d["a"] = "assign"; d["v"] = "variable"; d["p"] = "procedure"; d["q"] = "procedure";
 			d["ifs"] = "if";
-			s.insert("a");
+			s.push_back("a");
 			Optimizer op = Optimizer(st, w, p, s, d);
 			op.groupClause();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected1 = { { clause6, clause5 }, { clause3, clause4 }, {clause1} };
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected2 = { {clause2} };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected1 = { { c6, c5 }, { c3, c4 }, {c1} };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected2 = { {c2} };
 			Assert::IsTrue(result1 == expected1 && result2 == expected2);
 		}
 		TEST_METHOD(testTriviality)
@@ -197,25 +216,35 @@ namespace UnitTesting
 				std::make_pair("Uses", std::make_pair("ifs", "v"));
 			std::pair<std::string, std::pair<std::string, std::string>> clause4 =
 				std::make_pair("Call", std::make_pair("p", "q"));
-			std::pair<std::string, std::pair<std::string, std::string>> clause5 =
-				std::make_pair("with", std::make_pair("v.varName", str3));
-			std::pair<std::string, std::pair<std::string, std::string>> clause6 =
-				std::make_pair("with", std::make_pair("q.procName", str1));
+			std::pair<std::string, std::string> clause5 = std::make_pair("v.varName", str3);
+			std::pair<std::string, std::string> clause6 = std::make_pair("q.procName", str1);
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c1 =
+				std::make_pair(std::make_pair("pattern", "a"), std::make_pair(str1, str2));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c2 =
+				std::make_pair(std::make_pair("st", "Next*"), std::make_pair("s", "14"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c3 =
+				std::make_pair(std::make_pair("st", "Uses"), std::make_pair("ifs", "v"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c4 =
+				std::make_pair(std::make_pair("st", "Call"), std::make_pair("p", "q"));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c5 =
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("v.varName", str3));
+			std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> c6 =
+				std::make_pair(std::make_pair("with", "with"), std::make_pair("q.procName", str1));
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p;
 			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st;
-			std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w;
+			std::vector<std::pair<std::string, std::string>> w;
 			p.push_back(clause1);
 			st.push_back(clause2); st.push_back(clause3); st.push_back(clause4);
 			w.push_back(clause5); w.push_back(clause6);
-			s.insert("q"); s.insert("s");
+			s.push_back("q"); s.push_back("s");
 			d["a"] = "assign"; d["v"] = "variable"; d["p"] = "procedure"; d["q"] = "procedure";
 			d["ifs"] = "if"; d["s"] = "stmt"; 
 			Optimizer op = Optimizer(st, w, p, s, d);
 			op.groupClause();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected1 = { { clause5, clause3 }, {clause1} };
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
-			std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> expected2 = { { clause6, clause4 }, {clause2} };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result1 = op.getTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected1 = { { c5, c3 }, {c1} };
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> result2 = op.getNonTrivial();
+			std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> expected2 = { { c6, c4 }, {c2} };
 			Assert::IsTrue(result1 == expected1 && result2 == expected2);
 		}
 	};

--- a/Code/source/Optimizer.cpp
+++ b/Code/source/Optimizer.cpp
@@ -5,9 +5,9 @@
 */
 Optimizer::Optimizer(
 	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st,
-	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w,
+	std::vector<std::pair<std::string, std::string>> w,
 	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p, 
-	std::unordered_set<std::string> s, std::unordered_map<std::string, std::string> d) {
+	std::vector<std::string> s, std::unordered_map<std::string, std::string> d) {
 	suchThatClauses = st;
 	withClauses = w;
 	patternClauses = p;
@@ -89,7 +89,7 @@ void Optimizer::createMaps(std::vector<std::string> synLst, std::pair<int,int> c
 * Note: The actual clause, rather than the internal reference, is added to the results graph
 */
 bool Optimizer::mapClauses(std::pair<int,int> cl, bool isTrivial) {
-	std::pair<std::string, std::pair<std::string, std::string>> clause;
+	std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> clause;
 	clause = getClause(cl.second);
 	graph.push_back(clause);
 	clSet.erase(cl); //clause removed from bookkeeping sets
@@ -112,7 +112,7 @@ bool Optimizer::mapClauses(std::pair<int,int> cl, bool isTrivial) {
 */
 bool Optimizer::mapSynonym(std::string syn, bool isTrivial) {
 	//check if syn is part of select if group is trivial
-	if (isTrivial && (selectClause.find(syn) != selectClause.end())) {
+	if (isTrivial && (std::find(selectClause.begin(), selectClause.end(), syn) != selectClause.end())) {
 		isTrivial = false;
 	}
 	synSet.erase(syn); //synonym removed from bookkeeping sets
@@ -189,8 +189,8 @@ std::pair<int, std::vector<std::string>> Optimizer::extractPatternSyn(int index)
 
 std::pair<int, std::vector<std::string>> Optimizer::extractWithSyn(int index) {
 	std::vector<std::string> synLst;
-	std::string f = withClauses.at(index).second.first;
-	std::string s = withClauses.at(index).second.second;
+	std::string f = withClauses.at(index).first;
+	std::string s = withClauses.at(index).second;
 	int synNum = 0;
 	int i1 = 0;
 	if (OptimizerUtility::isWithSynonym(f)) {
@@ -222,23 +222,23 @@ std::pair<int, std::vector<std::string>> Optimizer::extractWithSyn(int index) {
 }
 
 /* Getter functions */
-std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> Optimizer::getTrivial() {
+std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> Optimizer::getTrivial() {
 	return trivial;
 }
-std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> Optimizer::getNonTrivial() {
+std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> Optimizer::getNonTrivial() {
 	return nontrivial;
 }
 
-std::pair<std::string, std::pair<std::string, std::string>> Optimizer::getClause(int cl) {
-	std::pair<std::string, std::pair<std::string, std::string>> clause;
+std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> Optimizer::getClause(int cl) {
+	std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> clause;
+	int index;
 	if (cl >= psize + wsize) {
-		clause = suchThatClauses.at(cl - psize - wsize);
-	}
-	else if (cl >= psize) {
-		clause = withClauses.at(cl - psize);
-	}
-	else {
-		clause = patternClauses.at(cl);
+		index = cl - psize - wsize;
+		clause = std::make_pair(std::make_pair("st", suchThatClauses.at(index).first), suchThatClauses.at(index).second);
+	} else if (cl >= psize) {
+		clause = std::make_pair(std::make_pair("with", "with"), withClauses.at(cl - psize));
+	} else {
+		clause = std::make_pair(std::make_pair("pattern", patternClauses.at(cl).first), patternClauses.at(cl).second);
 	}
 	return clause;
 }

--- a/Code/source/Optimizer.h
+++ b/Code/source/Optimizer.h
@@ -14,30 +14,30 @@
   This class optimises the evaluator by chaining the clauses together such that every other clause will have at least 1 clause evaluated
   
   // To use:
-  Optimizer op = Optimizer(st, w, p, s);
+  Optimizer op = Optimizer(st, w, p, s, d); // st/w/p -> suchthat/with/pattern, s-> select, d -> declarations 
   op.groupClause();
   
   // To get the groups of trivial/non-trivial clauses:
-  std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> trivial = op.getTrivial();
-  std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> nontrivial = op.getNonTrivial();
+  std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> trivial = op.getTrivial();
+  std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> nontrivial = op.getNonTrivial();
 */
 
 class Optimizer {
 private:
 	// these variables will be used as reference and will NOT be altered after creation
 	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> suchThatClauses;
-	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> withClauses;
+	std::vector<std::pair<std::string, std::string>> withClauses;
 	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> patternClauses;
 	int psize; //patternClauseSize
 	int wsize; //withClauseSize
-	std::unordered_set<std::string> selectClause;
+	std::vector<std::string> selectClause;
 	std::unordered_map<std::string, std::string> declarations;
 	std::unordered_map<std::string, std::priority_queue<std::pair<int,int>>> synMap;
 	std::unordered_map<int, std::vector<std::string>> clMap;
 	// these variables are used for storage of results
-	std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> trivial;
-	std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> nontrivial;
-	std::vector<std::pair<std::string, std::pair<std::string, std::string>>> graph;
+	std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> trivial;
+	std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> nontrivial;
+	std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>> graph;
 	// sets are used for bookkeeping to prevent infinite calls
 	std::unordered_set<std::string> synSet;
 	std::set<std::pair<int,int>, std::greater<std::pair<int, int>>> clSet;
@@ -46,18 +46,18 @@ private:
 	void createMaps(std::vector<std::string> synLst, std::pair<int,int> cl);
 	bool mapClauses(std::pair<int,int> cl, bool trivial);
 	bool mapSynonym(std::string syn, bool trivial);
-	std::pair<std::string, std::pair<std::string, std::string>> getClause(int cl);
+	std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>> getClause(int cl);
 public:
 	//Constructor
 	Optimizer(std::vector<std::pair<std::string, std::pair<std::string, std::string>>> st,
-		std::vector<std::pair<std::string, std::pair<std::string, std::string>>> w,
+		std::vector<std::pair<std::string, std::string>> w,
 		std::vector<std::pair<std::string, std::pair<std::string, std::string>>> p,
-		std::unordered_set<std::string> s, std::unordered_map<std::string, std::string> d);
+		std::vector<std::string> s, std::unordered_map<std::string, std::string> d);
 	//Statement to process
 	void groupClause();
 	//Getter Functions
-	std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> getTrivial();
-	std::vector<std::vector<std::pair<std::string, std::pair<std::string, std::string>>>> getNonTrivial();
+	std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> getTrivial();
+	std::vector<std::vector<std::pair<std::pair<std::string, std::string>, std::pair<std::string, std::string>>>> getNonTrivial();
 	//Priority and Syn Extractor (For Unit Testing -- this should otherwise be kept private)
 	std::pair<int, std::vector<std::string>> extractSuchThatSyn(int index);
 	std::pair<int, std::vector<std::string>> extractWithSyn(int index);


### PR DESCRIPTION
Arrangements of clauses will cause different types of clauses to be mixed into a single vector. Output format of optimizer is changed to allow for identification of clause type by evaluator.
Change of format: 
initial clause (pair<string, pair<string, string>>) to
current clause (pair<**pair<string,string>**, pair<string, string>)
Changes to clause contents:
1. Such that clauses will be changed in the following manner:
<Relation, <arg1, arg2>> to <<**st**, Relation>, <arg1, arg2>>
e.g. <Follows, <a, b>> ---->---- <<st, Follows>, <a, b>>
2. Pattern clauses will be changed to the following:
<synonym, <arg1, arg2>> to <<**pattern**, synonym>, <arg1, arg2>>
e.g. <a, <v, _>> ---->---- <<pattern, a>, <v, _>>
3. With clauses will be changed to the following:
<arg1, arg2> to <<**with**, **with**>, <arg1, arg2>>
e.g. <v.varName, "varA"> ---->----  <<with, with>, <v.varName, "varA">>