### PR TITLE
Iteration 3 Fixes

### DIFF
--- a/Code/UnitTesting/Utility/ExpressionUtilTest.cpp
+++ b/Code/UnitTesting/Utility/ExpressionUtilTest.cpp
@@ -12,7 +12,7 @@ namespace UnitTesting
 		TEST_METHOD(convertInfix1Variable)
 		{
 			std::string testStatement = "a";
-			std::string expectedOutput = "a";
+			std::string expectedOutput = " a ";
 			bool validExpression = ExpressionUtil::verifyInfixExpression(testStatement);
 
 			Assert::IsTrue(validExpression);
@@ -62,7 +62,7 @@ namespace UnitTesting
 		TEST_METHOD(test2OperandConversion)
 		{
 			std::string testStatement = "x+6";
-			std::string expectedConvert = "+ x 6";
+			std::string expectedConvert = " + x 6 ";
 
 			std::string output = ExpressionUtil::convertInfixToPrefix(testStatement);
 
@@ -72,7 +72,7 @@ namespace UnitTesting
 		TEST_METHOD(test3OperandConversion)
 		{
 			std::string testStatement = "xy+995+lcz";
-			std::string expectedConvert = "+ + xy 995 lcz";
+			std::string expectedConvert = " + + xy 995 lcz ";
 
 			std::string output = ExpressionUtil::convertInfixToPrefix(testStatement);
 
@@ -82,7 +82,7 @@ namespace UnitTesting
 		TEST_METHOD(test4OperandConversion)
 		{
 			std::string testStatement = "5*95+                vvv/4";
-			std::string expectedConvert = "+ * 5 95 / vvv 4";
+			std::string expectedConvert = " + * 5 95 / vvv 4 ";
 
 			std::string output = ExpressionUtil::convertInfixToPrefix(testStatement);
 
@@ -102,13 +102,26 @@ namespace UnitTesting
 			Assert::AreEqual(expectedConvert, testStatement);
 		}
 
+		TEST_METHOD(test4OperandWithBracketComplexPreProcess)
+		{
+			std::string testStatement = "(  ((5*(        6*   (a+b) )/ 5)    ))";
+
+
+
+			std::string expectedConvert = "( ( ( 5 * ( 6 * ( a + b ) ) / 5 ) ) )";
+
+			ExpressionUtil::expressionPreprocess(testStatement);
+
+			Assert::AreEqual(expectedConvert, testStatement);
+		}
+
 		TEST_METHOD(test4OperandWithBracketConversion)
 		{
 			std::string testStatement = "5*(a+b) / 5";
 
 
 
-			std::string expectedConvert = "/ * 5 + a b 5";
+			std::string expectedConvert = " / * 5 + a b 5 ";
 
 			std::string output = ExpressionUtil::convertInfixToPrefix(testStatement);
 
@@ -164,7 +177,7 @@ namespace UnitTesting
 			std::string testExpression = "a + ( ( b - c) )";
 
 			std::string output = ExpressionUtil::convertInfixToPrefix(testExpression);
-			std::string expectedOutput = "+ a - b c";
+			std::string expectedOutput = " + a - b c ";
 			Assert::AreEqual(expectedOutput, output);
 
 		}

--- a/Code/source/ExpressionUtil.cpp
+++ b/Code/source/ExpressionUtil.cpp
@@ -88,7 +88,7 @@ std::string ExpressionUtil::convertInfixToPrefix(std::string expression) {
 		operandStack.push(subexpre);
 	}
 			
-	return operandStack.top();
+	return " " + operandStack.top() + " ";
 }
 
 /* This function performs white space cleaning of an infix expression.

--- a/Code/source/RunTimeDesignExtractor.cpp
+++ b/Code/source/RunTimeDesignExtractor.cpp
@@ -206,40 +206,76 @@ bool RunTimeDesignExtractor::isStatementAffectedByAnother(int stmt) {
 		return false;
 	}
 	std::unordered_set<int> cfgPath;
-	return DFSRecursiveCheckAffectedBy(stmt, stmt, cfgPath, true);
+	std::unordered_set<std::string> relevantVar;
+	return DFSRecursiveCheckAffectedBy(stmt, stmt, cfgPath, true, relevantVar);
 }
 
-bool RunTimeDesignExtractor::DFSRecursiveCheckAffectedBy(int end, int current, std::unordered_set<int> &cfgPath, bool isStart) {
+bool RunTimeDesignExtractor::DFSRecursiveCheckAffectedBy(int end, int current, std::unordered_set<int> &cfgPath, bool isStart, std::unordered_set<std::string> &relevantVar) {
 	//If is not starting node we will not check if it affects or breaks affects
 	//Subsequently, if we visit the starting node again we will go into this clause.
+	//If we find that affects is possible we return as we know anything above it in the CFG cannot affect the end statemnt.
+	std::unordered_set<std::string> usedList = pkb->getVarUsedByStm(end);
+	std::unordered_set<std::string> modifiedVar;
+
+	//Not first node
 	if (!isStart) {
-		if (isAffectPossible(current, end)) {
-			return true;
+		//If the current can modify
+		if (pkb->getStmType(current) == stmType::assign || pkb->getStmType(current) == stmType::call || pkb->getStmType(current) == stmType::read) {
+			modifiedVar = pkb->getVarModifiedByStm(current);
+
+
+			for (std::string var : modifiedVar) {
+				std::unordered_set<std::string>::const_iterator alreadyModified = relevantVar.find(var);
+				//Check if what current is modifying has not already been modified later on
+				if (alreadyModified == relevantVar.end()) {
+					//if not modified in the future, we accept it as a possible value if end uses it
+					if (usedList.find(var) != usedList.end()) {
+						//We only add if the current is an assign statement.
+						if (pkb->getStmType(current) == stmType::assign) {
+							return true;
+						}
+						//we mark it as modified.
+						relevantVar.insert(var);
+					}
+				}
+			}
 		}
 	}
 
-	//Add stmt to CFGPath if is start of DFS
+	//Early return if the var used by statement has already all been found.
+	if (pkb->getVarUsedByStm(end) == relevantVar) {
+		for (std::string var : modifiedVar) {
+			relevantVar.erase(var);
+		}
+		return false;
+	}
+
+	//Add stmt to CFGPath if is not start of DFS
 	//Subsequently it will always add to cfgPath
 	if (!isStart) {
 		cfgPath.insert(current);
 	}
 
-	//Get neighbouring prev statements
+	//Get neighbouring next statements
 	std::unordered_set<int> prevStatements = pkb->getPrev(current);
 
-	//For each neighbouring prev statements
+	//For each neighbouring procedure
 	for (int prevStmt : prevStatements) {
 
-		//Check if prev Statemnt is inside the CFGPath.
+		//Check if next Statemnt is inside the CFGPath.
 		std::unordered_set<int>::const_iterator currPath = cfgPath.find(prevStmt);
 
 		//If next statement has not been visited, visit it.
 		if (currPath == cfgPath.end()) {
-			bool result = DFSRecursiveCheckAffecting(end, prevStmt, cfgPath, false);
-			if (result) {
+			bool found = DFSRecursiveCheckAffectedBy(end, prevStmt, cfgPath, false, relevantVar);
+			if (found) {
 				return true;
 			}
 		}
+	}
+
+	for (std::string var : modifiedVar) {
+		relevantVar.erase(var);
 	}
 	return false;
 }

--- a/Code/source/RunTimeDesignExtractor.cpp
+++ b/Code/source/RunTimeDesignExtractor.cpp
@@ -728,9 +728,9 @@ std::unordered_set<std::pair<int, int>, intPairhash> RunTimeDesignExtractor::get
 	std::unordered_set<std::pair<int, int>, intPairhash> finalResult;
 
 	for (std::pair<int, int> affectPair : relevantPairs) {
-		std::unordered_set<int> adjacents = adjacencyList[affectPair.second];
-		adjacents.insert(affectPair.first);
-		adjacencyList[affectPair.second] = adjacents;
+		std::unordered_set<int> adjacents = adjacencyList[affectPair.first];
+		adjacents.insert(affectPair.second);
+		adjacencyList[affectPair.first] = adjacents;
 	}
 
 	int simpleSize = pkb->getTotalStmNo();
@@ -739,7 +739,7 @@ std::unordered_set<std::pair<int, int>, intPairhash> RunTimeDesignExtractor::get
 		std::vector<int> results;
 		std::unordered_set<int> visitedPath;
 
-		DFSRecursiveReachability(i, results, visitedPath, adjacencyList, false);
+		DFSRecursiveReachability(i, results, visitedPath, adjacencyList, true);
 
 		for (int result : results) {
 			finalResult.insert(std::make_pair(i, result));

--- a/Code/source/RunTimeDesignExtractor.h
+++ b/Code/source/RunTimeDesignExtractor.h
@@ -105,7 +105,7 @@ private:
 	bool DFSRecursiveCheckAffecting(int start, int current, std::unordered_set<int>& cfgPath, bool isStart);
 
 	//For DFSing Affects(_, int)
-	bool DFSRecursiveCheckAffectedBy(int end, int current, std::unordered_set<int>& cfgPath, bool isStart);
+	bool DFSRecursiveCheckAffectedBy(int end, int current, std::unordered_set<int>& cfgPath, bool isStart, std::unordered_set<std::string> & relevantVar);
 
 	//For DFSing Affects(synonym, int)
 	void DFSRecursiveGetAffectingList(int end, int current, std::unordered_set<int>& cfgPath, bool isStart, std::vector<int>& affectedByList, std::unordered_set<std::string>& relevantVar);


### PR DESCRIPTION
1. Fix an issue in ExpressionUtil where a previous fix was reverted. prefix Expression now prepends and postpend result with spaces.

2. Fix an issue where Affects(_,int) had the wrong logic.

3. Fix an issue where Affets*(syn,syn) was not initialized properly.

